### PR TITLE
Add JSON schema validation for pack entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,23 @@
 {
   "name": "handy-dandy",
-  "version": "0.13.7",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "handy-dandy",
-      "version": "0.13.7",
+      "version": "1.0.0",
       "dependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "openai": "^5.0.1"
       },
       "devDependencies": {
-        "@league-of-foundry-developers/foundry-vtt-types": "^12.331.5",
         "copy-webpack-plugin": "^13.0.0",
         "fork-ts-checker-webpack-plugin": "^9.0.0",
         "fvtt-types": "npm:@league-of-foundry-developers/foundry-vtt-types@^12.331.5",
         "ts-loader": "^9.5.2",
+        "tsx": "^4.16.2",
         "typescript": "^5.4.0",
         "webpack": "^5.99.9",
         "webpack-cli": "^6.0.1"
@@ -54,6 +56,448 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -118,45 +562,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@league-of-foundry-developers/foundry-vtt-types": {
-      "version": "12.331.5",
-      "resolved": "https://registry.npmjs.org/@league-of-foundry-developers/foundry-vtt-types/-/foundry-vtt-types-12.331.5.tgz",
-      "integrity": "sha512-Ncyv5W5dtE8LdVxjYLfrx2ujQIuBPch5bDcnHaqKTL4wVEE8jgCE7amPkGHltFLilLTZ7Ki3veuFDURzpDIgbg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pixi/basis": "^7.4.2",
-        "@pixi/graphics-smooth": "^1.1.0",
-        "@pixi/particle-emitter": "^5.0.8",
-        "@types/earcut": "^3.0.0",
-        "@types/jquery": "~3.5.22",
-        "@types/showdown": "~2.0.6",
-        "@types/simple-peer": "~9.11.1",
-        "@types/youtube": "~0.0.48",
-        "earcut": "^3.0.1",
-        "handlebars": "^4.7.8",
-        "pixi.js": "^7.4.2",
-        "postinstall-postinstall": "^2.1.0",
-        "prosemirror-collab": "^1.3.1",
-        "prosemirror-commands": "^1.5.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.0",
-        "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.21.0",
-        "prosemirror-schema-list": "^1.3.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.3.7",
-        "prosemirror-transform": "^1.9.0",
-        "prosemirror-view": "^1.33.6",
-        "socket.io-client": "^4.7.5",
-        "tinymce": "^6.8.3"
-      },
-      "peerDependencies": {
-        "typescript": "^5.4"
       }
     },
     "node_modules/@pixi/accessibility": {
@@ -978,7 +1383,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -992,10 +1396,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -1539,6 +1942,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1617,7 +2062,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1631,7 +2075,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1809,6 +2252,21 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1896,6 +2354,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.12.0.tgz",
+      "integrity": "sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob-parent": {
@@ -2195,7 +2666,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -2818,7 +3288,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2868,6 +3337,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -2914,6 +3393,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/semver": {
@@ -3301,6 +3798,26 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -4,18 +4,22 @@
   "type": "module",
   "scripts": {
     "build": "webpack --mode production",
-    "test": "webpack --mode production && xcopy /s /e /y /i dist \"%LOCALAPPDATA%\\FoundryVTT\\Data\\modules\\handy-dandy\\\""
+    "test": "webpack --mode production && xcopy /s /e /y /i dist \"%LOCALAPPDATA%\\FoundryVTT\\Data\\modules\\handy-dandy\\\"",
+    "test:validation": "tsx --test tests/validation.test.ts"
   },
   "overrides": {
     "@types/earcut": "3.0.0"
   },
   "dependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "openai": "^5.0.1"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^13.0.0",
     "fork-ts-checker-webpack-plugin": "^9.0.0",
     "fvtt-types": "npm:@league-of-foundry-developers/foundry-vtt-types@^12.331.5",
+    "tsx": "^4.16.2",
     "ts-loader": "^9.5.2",
     "typescript": "^5.4.0",
     "webpack": "^5.99.9",

--- a/src/scripts/helpers/validation.ts
+++ b/src/scripts/helpers/validation.ts
@@ -1,0 +1,30 @@
+import type { ErrorObject } from "ajv";
+import { validators, type ValidatorKey } from "../schemas";
+
+export type ValidationResult = { ok: true } | { ok: false; errors: string[] };
+
+const validatorMap = validators;
+
+export function validate(entityType: ValidatorKey, data: unknown): ValidationResult {
+  const validator = validatorMap[entityType];
+  const valid = validator(data);
+
+  if (valid) {
+    return { ok: true };
+  }
+
+  const errors = (validator.errors ?? []).map(formatError);
+  return { ok: false, errors };
+}
+
+function formatError(error: ErrorObject): string {
+  if (error.keyword === "additionalProperties") {
+    const { additionalProperty } = error.params as { additionalProperty: string };
+    const basePath = error.instancePath.replace(/\//g, ".").replace(/^\./, "");
+    const path = basePath ? `${basePath}.${additionalProperty}` : additionalProperty;
+    return `${path}: ${error.message ?? "must NOT have additional properties"}`;
+  }
+
+  const path = error.instancePath ? error.instancePath.slice(1).replace(/\//g, ".") : "(root)";
+  return `${path}: ${error.message ?? "is invalid"}`;
+}

--- a/src/scripts/schemas/index.ts
+++ b/src/scripts/schemas/index.ts
@@ -1,0 +1,223 @@
+import Ajv, { JSONSchemaType, ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
+
+export const SYSTEM_IDS = ["pf2e", "sf2e"] as const;
+export type SystemId = (typeof SYSTEM_IDS)[number];
+
+export const ACTION_EXECUTIONS = [
+  "one-action",
+  "two-actions",
+  "three-actions",
+  "reaction",
+  "free-action",
+  "passive"
+] as const;
+export type ActionExecution = (typeof ACTION_EXECUTIONS)[number];
+
+export const ITEM_CATEGORIES = [
+  "armor",
+  "weapon",
+  "equipment",
+  "consumable",
+  "feat",
+  "spell",
+  "wand",
+  "staff",
+  "other"
+] as const;
+export type ItemCategory = (typeof ITEM_CATEGORIES)[number];
+
+export const ACTOR_CATEGORIES = [
+  "character",
+  "npc",
+  "hazard",
+  "vehicle",
+  "familiar"
+] as const;
+export type ActorCategory = (typeof ACTOR_CATEGORIES)[number];
+
+export const RARITIES = ["common", "uncommon", "rare", "unique"] as const;
+export type Rarity = (typeof RARITIES)[number];
+
+export const ENTITY_TYPES = ["action", "item", "actor"] as const;
+export type EntityType = (typeof ENTITY_TYPES)[number];
+
+type BaseEntity<TType extends EntityType> = {
+  schema_version: 1;
+  systemId: SystemId;
+  type: TType;
+  slug: string;
+  name: string;
+};
+
+export interface ActionSchemaData extends BaseEntity<"action"> {
+  actionType: ActionExecution;
+  traits?: string[];
+  requirements?: string;
+  description: string;
+  img?: string;
+  rarity?: Rarity;
+}
+
+export interface ItemSchemaData extends BaseEntity<"item"> {
+  itemType: ItemCategory;
+  rarity: Rarity;
+  level: number;
+  price?: number;
+  traits?: string[];
+  description?: string;
+  img?: string;
+}
+
+export interface ActorSchemaData extends BaseEntity<"actor"> {
+  actorType: ActorCategory;
+  rarity: Rarity;
+  level: number;
+  traits?: string[];
+  languages?: string[];
+  img?: string;
+}
+
+export interface PackEntrySchemaData {
+  schema_version: 1;
+  systemId: SystemId;
+  id: string;
+  entityType: EntityType;
+  name: string;
+  slug: string;
+  img?: string;
+  sort?: number;
+  folder?: string | null;
+}
+
+const baseMeta = {
+  schema_version: { type: "integer", enum: [1], default: 1 as const },
+  systemId: { type: "string", enum: SYSTEM_IDS, default: "pf2e" as const },
+  slug: { type: "string", minLength: 1 },
+  name: { type: "string", minLength: 1 }
+} as const;
+
+export const actionSchema = {
+  $id: "Action",
+  type: "object",
+  additionalProperties: false,
+  required: ["schema_version", "systemId", "type", "slug", "name", "actionType", "description"],
+  properties: {
+    ...baseMeta,
+    type: { type: "string", enum: ["action"] as const },
+    actionType: { type: "string", enum: ACTION_EXECUTIONS },
+    traits: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      default: [] as const
+    },
+    requirements: { type: "string", default: "" },
+    description: { type: "string", minLength: 1 },
+    img: { type: "string", format: "uri-reference", default: "" },
+    rarity: { type: "string", enum: RARITIES, default: "common" as const }
+  }
+} satisfies JSONSchemaType<ActionSchemaData>;
+
+export const itemSchema = {
+  $id: "Item",
+  type: "object",
+  additionalProperties: false,
+  required: ["schema_version", "systemId", "type", "slug", "name", "itemType", "rarity", "level"],
+  properties: {
+    ...baseMeta,
+    type: { type: "string", enum: ["item"] as const },
+    itemType: { type: "string", enum: ITEM_CATEGORIES },
+    rarity: { type: "string", enum: RARITIES },
+    level: { type: "integer", minimum: 0 },
+    price: { type: "number", minimum: 0, default: 0 },
+    traits: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      default: [] as const
+    },
+    description: { type: "string", default: "" },
+    img: { type: "string", format: "uri-reference", default: "" }
+  }
+} satisfies JSONSchemaType<ItemSchemaData>;
+
+export const actorSchema = {
+  $id: "Actor",
+  type: "object",
+  additionalProperties: false,
+  required: ["schema_version", "systemId", "type", "slug", "name", "actorType", "rarity", "level"],
+  properties: {
+    ...baseMeta,
+    type: { type: "string", enum: ["actor"] as const },
+    actorType: { type: "string", enum: ACTOR_CATEGORIES },
+    rarity: { type: "string", enum: RARITIES },
+    level: { type: "integer", minimum: 0 },
+    traits: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      default: [] as const
+    },
+    languages: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      default: [] as const
+    },
+    img: { type: "string", format: "uri-reference", default: "" }
+  }
+} satisfies JSONSchemaType<ActorSchemaData>;
+
+export const packEntrySchema = {
+  $id: "PackEntry",
+  type: "object",
+  additionalProperties: false,
+  required: ["schema_version", "systemId", "id", "entityType", "name", "slug"],
+  properties: {
+    schema_version: baseMeta.schema_version,
+    systemId: baseMeta.systemId,
+    id: { type: "string", minLength: 1 },
+    entityType: { type: "string", enum: ENTITY_TYPES },
+    name: baseMeta.name,
+    slug: baseMeta.slug,
+    img: { type: "string", format: "uri-reference", default: "" },
+    sort: { type: "integer", default: 0 },
+    folder: { type: "string", nullable: true, default: null }
+  }
+} satisfies JSONSchemaType<PackEntrySchemaData>;
+
+export const schemas = {
+  action: actionSchema,
+  item: itemSchema,
+  actor: actorSchema,
+  packEntry: packEntrySchema
+} as const;
+
+export type SchemaMap = typeof schemas;
+
+const ajv = new Ajv({
+  strict: true,
+  allErrors: true,
+  useDefaults: true
+});
+addFormats(ajv);
+
+export const validators: {
+  [K in keyof SchemaMap]: ValidateFunction<
+    K extends "action"
+      ? ActionSchemaData
+      : K extends "item"
+        ? ItemSchemaData
+        : K extends "actor"
+          ? ActorSchemaData
+          : PackEntrySchemaData
+  >;
+} = {
+  action: ajv.compile<ActionSchemaData>(actionSchema),
+  item: ajv.compile<ItemSchemaData>(itemSchema),
+  actor: ajv.compile<ActorSchemaData>(actorSchema),
+  packEntry: ajv.compile<PackEntrySchemaData>(packEntrySchema)
+};
+
+export type ValidatorMap = typeof validators;
+export type ValidatorKey = keyof ValidatorMap;
+export type EntityValidator = ValidatorMap[keyof ValidatorMap];
+
+export { ajv as ajvInstance };

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type {
+  ActionSchemaData,
+  ActorSchemaData,
+  ItemSchemaData,
+  PackEntrySchemaData
+} from "../src/scripts/schemas";
+import { validate } from "../src/scripts/helpers/validation";
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const validAction: ActionSchemaData = {
+  schema_version: 1,
+  systemId: "pf2e",
+  type: "action",
+  slug: "test-action",
+  name: "Test Action",
+  actionType: "one-action",
+  traits: ["attack"],
+  description: "You do something impressive.",
+  requirements: ""
+};
+
+const validItem: ItemSchemaData = {
+  schema_version: 1,
+  systemId: "pf2e",
+  type: "item",
+  slug: "test-item",
+  name: "Test Item",
+  itemType: "equipment",
+  rarity: "common",
+  level: 1,
+  price: 10,
+  traits: ["magical"],
+  description: "A handy trinket."
+};
+
+const validActor: ActorSchemaData = {
+  schema_version: 1,
+  systemId: "pf2e",
+  type: "actor",
+  slug: "test-actor",
+  name: "Test Actor",
+  actorType: "npc",
+  rarity: "common",
+  level: 3,
+  traits: ["humanoid"],
+  languages: ["Common"]
+};
+
+const validPackEntry: PackEntrySchemaData = {
+  schema_version: 1,
+  systemId: "pf2e",
+  id: "entry-1",
+  entityType: "action",
+  name: "Test Entry",
+  slug: "test-entry"
+};
+
+test("valid fixtures pass validation", () => {
+  assert.deepStrictEqual(validate("action", clone(validAction)), { ok: true });
+  assert.deepStrictEqual(validate("item", clone(validItem)), { ok: true });
+  assert.deepStrictEqual(validate("actor", clone(validActor)), { ok: true });
+  assert.deepStrictEqual(validate("packEntry", clone(validPackEntry)), { ok: true });
+});
+
+test("invalid action enum produces helpful error", () => {
+  const result = validate("action", { ...clone(validAction), actionType: "quad-action" as any });
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.includes("actionType: must be equal to one of the allowed values"),
+    `Unexpected errors: ${result.errors.join(", ")}`
+  );
+});
+
+test("extra fields are reported for items", () => {
+  const result = validate("item", { ...clone(validItem), extra: true } as Record<string, unknown>);
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.errors.includes("extra: must NOT have additional properties"),
+    `Unexpected errors: ${result.errors.join(", ")}`
+  );
+});


### PR DESCRIPTION
## Summary
- add Ajv-powered JSON Schema definitions for actions, items, actors, and pack entries
- expose reusable validators and a helper that reports readable Ajv error messages
- cover the validators with TypeScript tests for both valid and invalid fixtures

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68e9c0da1648832f852850e9d577656d