### PR TITLE
Update validation error reporting

### DIFF
--- a/src/scripts/schemas/index.ts
+++ b/src/scripts/schemas/index.ts
@@ -8,9 +8,8 @@ export const ACTION_EXECUTIONS = [
   "one-action",
   "two-actions",
   "three-actions",
-  "reaction",
-  "free-action",
-  "passive"
+  "free",
+  "reaction"
 ] as const;
 export type ActionExecution = (typeof ACTION_EXECUTIONS)[number];
 


### PR DESCRIPTION
## Summary
- align the action execution enum with the current specification
- expose raw Ajv validation errors with helpers for formatting messages
- adjust validation tests to cover the new error structure

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68e9c5f61458832f80c126951285df17