### PR TITLE
Add GPT client helper for structured outputs

### DIFF
--- a/src/scripts/gpt/client.ts
+++ b/src/scripts/gpt/client.ts
@@ -1,0 +1,219 @@
+import type { OpenAI } from "openai";
+import { CONSTANTS } from "../constants";
+
+export interface JsonSchemaDefinition {
+  name: string;
+  schema: Record<string, unknown>;
+  description?: string;
+}
+
+export interface GPTClientConfig {
+  model: string;
+  temperature: number;
+  top_p: number;
+  seed?: number;
+}
+
+const sanitizeNumber = (value: unknown): number | undefined => {
+  if (typeof value !== "number") return undefined;
+  return Number.isFinite(value) ? value : undefined;
+};
+
+export const readGPTSettings = (): GPTClientConfig => {
+  const settings = game.settings;
+  const model = settings?.get(CONSTANTS.MODULE_ID, "GPTModel") as string | undefined;
+  const temperature = settings?.get(CONSTANTS.MODULE_ID, "GPTTemperature");
+  const top_p = settings?.get(CONSTANTS.MODULE_ID, "GPTTopP");
+  const seedSetting = settings?.get(CONSTANTS.MODULE_ID, "GPTSeed");
+
+  const config: GPTClientConfig = {
+    model: model ?? "gpt-4.1-mini",
+    temperature: sanitizeNumber(temperature) ?? 0,
+    top_p: sanitizeNumber(top_p) ?? 1,
+  };
+
+  const seed = sanitizeNumber(seedSetting);
+  if (typeof seed === "number") {
+    config.seed = seed;
+  }
+
+  return config;
+};
+
+export class GPTClient {
+  #openai: OpenAI;
+  #config: GPTClientConfig;
+
+  constructor(openai: OpenAI, config: GPTClientConfig) {
+    this.#openai = openai;
+    this.#config = config;
+  }
+
+  static fromSettings(openai: OpenAI): GPTClient {
+    return new GPTClient(openai, readGPTSettings());
+  }
+
+  async generateWithSchema<T>(prompt: string, schema: JsonSchemaDefinition): Promise<T> {
+    try {
+      return await this.#generateStructured<T>(prompt, schema);
+    } catch (error) {
+      if (!this.#shouldFallback(error)) throw error;
+      return await this.#generateWithTool<T>(prompt, schema);
+    }
+  }
+
+  async #generateStructured<T>(prompt: string, schema: JsonSchemaDefinition): Promise<T> {
+    const response = await this.#openai.responses.create({
+      model: this.#config.model,
+      input: prompt,
+      temperature: this.#config.temperature,
+      top_p: this.#config.top_p,
+      seed: this.#config.seed,
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: schema.name,
+          schema: schema.schema,
+          strict: true,
+        },
+      },
+    });
+
+    return this.#extractJson<T>(response, schema);
+  }
+
+  async #generateWithTool<T>(prompt: string, schema: JsonSchemaDefinition): Promise<T> {
+    const response = await this.#openai.responses.create({
+      model: this.#config.model,
+      temperature: this.#config.temperature,
+      top_p: this.#config.top_p,
+      seed: this.#config.seed,
+      input: [
+        {
+          role: "system",
+          content: `You are a JSON serializer. Always provide valid JSON for the ${schema.name} tool that satisfies the supplied schema.`,
+        },
+        { role: "user", content: prompt },
+      ],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: schema.name,
+            description: schema.description ?? "Return JSON matching the provided schema.",
+            parameters: schema.schema,
+            strict: true,
+          },
+        },
+      ],
+      tool_choice: { type: "function", function: { name: schema.name } },
+    });
+
+    return this.#extractJson<T>(response, schema);
+  }
+
+  #shouldFallback(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const candidate = error as Error & { status?: number; code?: string };
+    if (typeof candidate.code === "string" && candidate.code.toLowerCase().includes("response_format")) {
+      return true;
+    }
+    if (typeof candidate.status === "number" && candidate.status >= 400 && candidate.status < 500) {
+      return true;
+    }
+    if (typeof candidate.message === "string" && candidate.message.toLowerCase().includes("response_format")) {
+      return true;
+    }
+    return false;
+  }
+
+  #extractJson<T>(response: unknown, schema: JsonSchemaDefinition): T {
+    // Structured response format
+    if (response && typeof response === "object") {
+      const structured = this.#extractFromOutput<T>(response as Record<string, unknown>);
+      if (structured !== undefined) return structured;
+
+      const fromChoices = this.#extractFromChoices<T>(response as Record<string, unknown>);
+      if (fromChoices !== undefined) return fromChoices;
+    }
+
+    throw new Error(`Unable to parse JSON response for schema "${schema.name}"`);
+  }
+
+  #extractFromOutput<T>(response: Record<string, unknown>): T | undefined {
+    const output = response.output;
+    if (!Array.isArray(output)) return undefined;
+
+    for (const block of output) {
+      if (!block || typeof block !== "object") continue;
+      const content = (block as { content?: unknown }).content;
+      if (!Array.isArray(content)) continue;
+      for (const item of content) {
+        if (!item || typeof item !== "object") continue;
+        const type = (item as { type?: unknown }).type;
+        if (type === "output_json") {
+          const json = (item as { json?: unknown }).json;
+          if (json && typeof json === "object") return json as T;
+        }
+        if (type === "output_text") {
+          const text = (item as { text?: unknown }).text;
+          const parsed = this.#tryParseText<T>(text);
+          if (parsed !== undefined) return parsed;
+        }
+        if (type === "text") {
+          const text = (item as { text?: unknown }).text;
+          const parsed = this.#tryParseText<T>(text);
+          if (parsed !== undefined) return parsed;
+        }
+        if (type === "tool_call") {
+          const toolCall = (item as { tool_call?: unknown }).tool_call;
+          if (toolCall && typeof toolCall === "object") {
+            const args = (toolCall as { arguments?: unknown }).arguments;
+            const parsed = this.#tryParseText<T>(args);
+            if (parsed !== undefined) return parsed;
+          }
+        }
+      }
+    }
+
+    const outputText = (response as { output_text?: unknown }).output_text;
+    const parsed = this.#tryParseText<T>(outputText);
+    return parsed;
+  }
+
+  #extractFromChoices<T>(response: Record<string, unknown>): T | undefined {
+    const choices = response.choices;
+    if (!Array.isArray(choices)) return undefined;
+    for (const choice of choices) {
+      if (!choice || typeof choice !== "object") continue;
+      const message = (choice as { message?: unknown }).message;
+      if (!message || typeof message !== "object") continue;
+
+      const toolCalls = (message as { tool_calls?: unknown }).tool_calls;
+      if (Array.isArray(toolCalls)) {
+        for (const call of toolCalls) {
+          if (!call || typeof call !== "object") continue;
+          const fn = (call as { function?: unknown }).function;
+          if (!fn || typeof fn !== "object") continue;
+          const args = (fn as { arguments?: unknown }).arguments;
+          const parsed = this.#tryParseText<T>(args);
+          if (parsed !== undefined) return parsed;
+        }
+      }
+
+      const content = (message as { content?: unknown }).content;
+      const parsed = this.#tryParseText<T>(content);
+      if (parsed !== undefined) return parsed;
+    }
+    return undefined;
+  }
+
+  #tryParseText<T>(value: unknown): T | undefined {
+    if (typeof value !== "string") return undefined;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -5,12 +5,14 @@ import { OpenAI } from "openai";
 import { insertSidebarButtons } from "./setup/sidebarButtons";
 import { SchemaTool } from "./tools/schema-tool";
 import { DataEntryTool } from "./tools/data-entry-tool";
+import { GPTClient } from "./gpt/client";
 
 // ---------- module namespace ----------
 declare global {
   interface Game {
     handyDandy?: {
       openai: OpenAI | null,
+      gptClient: GPTClient | null,
       applications: {
         schemaTool: SchemaTool,
         dataEntryTool: DataEntryTool
@@ -37,7 +39,9 @@ Hooks.once("init", async () => {
 Hooks.once("setup", () => {
   // Provide a place other modules/macros can grab the SDK from
   game.handyDandy = {
-    openai: null, applications: {
+    openai: null,
+    gptClient: null,
+    applications: {
       schemaTool: new SchemaTool,
       dataEntryTool: new DataEntryTool
     }
@@ -56,10 +60,13 @@ Hooks.once("ready", () => {
   }
 
   // Store on the namespace for easy access later
-  game.handyDandy!.openai = new OpenAI({
+  const openai = new OpenAI({
     apiKey: key,
     dangerouslyAllowBrowser: true
   });
+
+  game.handyDandy!.openai = openai;
+  game.handyDandy!.gptClient = GPTClient.fromSettings(openai);
 
   console.log(`${CONSTANTS.MODULE_NAME} | OpenAI SDK initialised`);
 });

--- a/src/scripts/setup/settings.ts
+++ b/src/scripts/setup/settings.ts
@@ -21,4 +21,40 @@ export function registerSettings(): void {
     type: String,
     default: ""
   });
+
+  settings.register(CONSTANTS.MODULE_ID, "GPTModel", {
+    name: "GPT Model",
+    hint: "The OpenAI model identifier that should be used for Handy-Dandy prompts.",
+    scope: "client",
+    config: true,
+    type: String,
+    default: "gpt-4.1-mini"
+  });
+
+  settings.register(CONSTANTS.MODULE_ID, "GPTTemperature", {
+    name: "GPT Temperature",
+    hint: "Sampling temperature for OpenAI responses (0-2).",
+    scope: "client",
+    config: true,
+    type: Number,
+    default: 0.2
+  });
+
+  settings.register(CONSTANTS.MODULE_ID, "GPTTopP", {
+    name: "GPT Top P",
+    hint: "Nucleus sampling probability mass for OpenAI responses (0-1).",
+    scope: "client",
+    config: true,
+    type: Number,
+    default: 1
+  });
+
+  settings.register(CONSTANTS.MODULE_ID, "GPTSeed", {
+    name: "GPT Seed",
+    hint: "Optional deterministic seed for OpenAI responses (leave blank for random).",
+    scope: "client",
+    config: true,
+    type: Number,
+    default: null
+  });
 }

--- a/src/types/handy-dandy-settings.d.ts
+++ b/src/types/handy-dandy-settings.d.ts
@@ -8,6 +8,10 @@ declare module "fvtt-types/configuration" {
      */
     "handy-dandy.GPTApiKey": string;
     "handy-dandy.GPTOrganization": string;
+    "handy-dandy.GPTModel": string;
+    "handy-dandy.GPTTemperature": number;
+    "handy-dandy.GPTTopP": number;
+    "handy-dandy.GPTSeed": number | null;
   }
 }
 

--- a/tests/gpt-client.test.ts
+++ b/tests/gpt-client.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import type { OpenAI } from "openai";
+import { GPTClient, readGPTSettings } from "../src/scripts/gpt/client";
+
+type ResponsesCall = Record<string, any>;
+
+class StubResponses {
+  public calls: ResponsesCall[] = [];
+  private readonly queue: Array<() => Promise<unknown>> = [];
+
+  enqueue(response: unknown | Error): void {
+    if (response instanceof Error) {
+      this.queue.push(() => Promise.reject(response));
+    } else {
+      this.queue.push(() => Promise.resolve(response));
+    }
+  }
+
+  async create(input: ResponsesCall): Promise<unknown> {
+    this.calls.push(input);
+    const task = this.queue.shift();
+    if (!task) throw new Error("No stubbed response available");
+    return task();
+  }
+}
+
+class StubOpenAI {
+  public responses = new StubResponses();
+}
+
+const schema = {
+  name: "Example",
+  schema: {
+    type: "object",
+    properties: {
+      value: { type: "number" }
+    },
+    required: ["value"],
+    additionalProperties: false
+  }
+} as const;
+
+beforeEach(() => {
+  globalThis.game = {
+    settings: {
+      get(moduleId: string, key: string) {
+        if (moduleId !== "handy-dandy") throw new Error("Unknown module");
+        const values: Record<string, unknown> = {
+          GPTModel: "test-model",
+          GPTTemperature: 0.5,
+          GPTTopP: 0.75,
+          GPTSeed: 123,
+        };
+        return values[key] ?? null;
+      }
+    }
+  } as any;
+});
+
+test("readGPTSettings pulls module settings with sane defaults", () => {
+  const config = readGPTSettings();
+  assert.deepEqual(config, {
+    model: "test-model",
+    temperature: 0.5,
+    top_p: 0.75,
+    seed: 123,
+  });
+});
+
+test("generateWithSchema returns parsed JSON from structured outputs", async () => {
+  const stub = new StubOpenAI();
+  stub.responses.enqueue({
+    output: [
+      {
+        type: "message",
+        content: [
+          {
+            type: "output_json",
+            json: { value: 42 }
+          }
+        ]
+      }
+    ]
+  });
+
+  const client = GPTClient.fromSettings(stub as unknown as OpenAI);
+  const result = await client.generateWithSchema<{ value: number }>("Say hello", schema);
+
+  assert.deepEqual(result, { value: 42 });
+
+  const [call] = stub.responses.calls;
+  assert.equal(call.response_format?.json_schema?.name, schema.name);
+  assert.equal(call.response_format?.json_schema?.strict, true);
+});
+
+test("generateWithSchema falls back to tool calls when response_format unsupported", async () => {
+  const stub = new StubOpenAI();
+  const error = new Error("This model does not support response_format");
+  (error as Error & { status?: number }).status = 400;
+  stub.responses.enqueue(error);
+  stub.responses.enqueue({
+    output: [
+      {
+        type: "message",
+        content: [
+          {
+            type: "tool_call",
+            tool_call: {
+              name: schema.name,
+              arguments: JSON.stringify({ value: 7 })
+            }
+          }
+        ]
+      }
+    ]
+  });
+
+  const client = GPTClient.fromSettings(stub as unknown as OpenAI);
+  const result = await client.generateWithSchema<{ value: number }>("Say hello", schema);
+
+  assert.deepEqual(result, { value: 7 });
+  assert.equal(stub.responses.calls.length, 2);
+
+  const [, fallbackCall] = stub.responses.calls;
+  assert.equal(Array.isArray(fallbackCall.tools), true);
+  assert.equal(fallbackCall.tool_choice?.function?.name, schema.name);
+});


### PR DESCRIPTION
## Summary
- add a GPT client helper that loads module settings and requests structured JSON responses with a tool-call fallback
- expose the helper on the module namespace and register new tuning settings
- cover the helper with unit tests that stub the OpenAI SDK

## Testing
- npx tsx --test tests/gpt-client.test.ts
- npx tsx --test tests/validation.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e9c68913c0832fba229d726167629b