### PR TITLE
Add deterministic prompt builders for entity schemas

### DIFF
--- a/src/scripts/prompts/actions.ts
+++ b/src/scripts/prompts/actions.ts
@@ -1,0 +1,62 @@
+import { ACTION_EXECUTIONS, RARITIES, actionSchema, type SystemId } from "../schemas/index";
+import { type CorrectionContext, wrapPrompt } from "./common";
+
+export interface ActionPromptInput {
+  readonly systemId: SystemId;
+  readonly title: string;
+  readonly referenceText: string;
+  readonly slug?: string;
+  readonly correction?: CorrectionContext;
+}
+
+function buildActionSchemaSection(): string {
+  const enumExecutions = ACTION_EXECUTIONS.join(", ");
+  const rarities = RARITIES.join(", ");
+  const schemaVersion = (actionSchema.properties.schema_version as { enum: readonly [number] }).enum[0];
+  const requirementsDefault = (actionSchema.properties.requirements as { default: string }).default;
+  const rarityDefault = (actionSchema.properties.rarity as { default: string }).default;
+  const traitsDefault = JSON.stringify(
+    (actionSchema.properties.traits as { default: readonly string[] }).default
+  );
+  const imgDefault = (actionSchema.properties.img as { default: string }).default;
+  return [
+    "Action schema overview:",
+    `- schema_version: integer literal ${schemaVersion}.`,
+    "- type: string literal \"action\".",
+    "- slug: non-empty string.",
+    "- name: non-empty string.",
+    `- actionType: string enum value (choose from: ${enumExecutions}).`,
+    "- description: non-empty string containing the full action rules.",
+    `- traits: optional array of non-empty strings; defaults to ${traitsDefault}.`,
+    `- requirements: optional string; defaults to "${requirementsDefault}".`,
+    `- img: optional string formatted as a URI reference; defaults to "${imgDefault}".`,
+    `- rarity: optional string enum (${rarities}); defaults to "${rarityDefault}".`
+  ].join("\n");
+}
+
+function buildActionRequest(input: ActionPromptInput): string {
+  const parts: string[] = [
+    `Create a ${input.systemId} action entry titled "${input.title}".`,
+    "Use the reference text verbatim where appropriate:",
+    input.referenceText.trim()
+  ];
+
+  if (input.slug) {
+    parts.splice(1, 0, `Slug suggestion: ${input.slug}`);
+  }
+
+  return parts.join("\n\n");
+}
+
+export function buildActionPrompt(input: ActionPromptInput): string {
+  const request = buildActionRequest(input);
+  return wrapPrompt(
+    "Generate a Foundry VTT Action JSON document.",
+    buildActionSchemaSection(),
+    {
+      request,
+      systemId: input.systemId,
+      correction: input.correction
+    }
+  );
+}

--- a/src/scripts/prompts/actors.ts
+++ b/src/scripts/prompts/actors.ts
@@ -1,0 +1,63 @@
+import { ACTOR_CATEGORIES, RARITIES, actorSchema, type SystemId } from "../schemas/index";
+import { type CorrectionContext, wrapPrompt } from "./common";
+
+export interface ActorPromptInput {
+  readonly systemId: SystemId;
+  readonly name: string;
+  readonly referenceText: string;
+  readonly slug?: string;
+  readonly correction?: CorrectionContext;
+}
+
+function buildActorSchemaSection(): string {
+  const categories = ACTOR_CATEGORIES.join(", ");
+  const rarities = RARITIES.join(", ");
+  const schemaVersion = (actorSchema.properties.schema_version as { enum: readonly [number] }).enum[0];
+  const traitsDefault = JSON.stringify(
+    (actorSchema.properties.traits as { default: readonly string[] }).default
+  );
+  const languagesDefault = JSON.stringify(
+    (actorSchema.properties.languages as { default: readonly string[] }).default
+  );
+  const imgDefault = (actorSchema.properties.img as { default: string }).default;
+  return [
+    "Actor schema overview:",
+    `- schema_version: integer literal ${schemaVersion}.`,
+    "- type: string literal \"actor\".",
+    "- slug: non-empty string.",
+    "- name: non-empty string.",
+    `- actorType: string enum (${categories}).`,
+    `- rarity: string enum (${rarities}).`,
+    "- level: integer >= 0.",
+    `- traits: optional array of non-empty strings; defaults to ${traitsDefault}.`,
+    `- languages: optional array of non-empty strings; defaults to ${languagesDefault}.`,
+    `- img: optional string formatted as a URI reference; defaults to "${imgDefault}".`
+  ].join("\n");
+}
+
+function buildActorRequest(input: ActorPromptInput): string {
+  const parts: string[] = [
+    `Create a ${input.systemId} actor entry named "${input.name}".`,
+    "Summarise the following reference text into structured data:",
+    input.referenceText.trim()
+  ];
+
+  if (input.slug) {
+    parts.splice(1, 0, `Slug suggestion: ${input.slug}`);
+  }
+
+  return parts.join("\n\n");
+}
+
+export function buildActorPrompt(input: ActorPromptInput): string {
+  const request = buildActorRequest(input);
+  return wrapPrompt(
+    "Generate a Foundry VTT Actor JSON document.",
+    buildActorSchemaSection(),
+    {
+      request,
+      systemId: input.systemId,
+      correction: input.correction
+    }
+  );
+}

--- a/src/scripts/prompts/common.ts
+++ b/src/scripts/prompts/common.ts
@@ -1,0 +1,65 @@
+import { SYSTEM_IDS, type SystemId } from "../schemas/index";
+
+export interface CorrectionContext {
+  readonly summary: string;
+  readonly previous: Record<string, unknown>;
+}
+
+export interface PromptBaseInput {
+  readonly request: string;
+  readonly systemId: SystemId;
+  readonly correction?: CorrectionContext;
+}
+
+function formatList(values: readonly string[]): string {
+  return values.map((value) => `- ${value}`).join("\n");
+}
+
+export function renderSystemIdSection(systemId: SystemId): string {
+  const allowedSystems = formatList([...SYSTEM_IDS]);
+  return [
+    "System ID handling:",
+    `- Allowed values:`,
+    allowedSystems,
+    `- Use the requested systemId: \"${systemId}\".`
+  ].join("\n");
+}
+
+export function renderCorrectionSection(correction?: CorrectionContext): string {
+  if (!correction) return "";
+  const serialized = JSON.stringify(correction.previous, null, 2);
+  return [
+    "Correction context:",
+    `- Reason: ${correction.summary}`,
+    "- Previous draft (update instead of recreating blindly):",
+    serialized
+  ].join("\n");
+}
+
+export function wrapPrompt(
+  title: string,
+  schemaSection: string,
+  input: PromptBaseInput
+): string {
+  const sections: string[] = [
+    title,
+    "Always respond with valid JSON matching the schema. Do not add commentary.",
+    renderSystemIdSection(input.systemId)
+  ];
+
+  const correctionSection = renderCorrectionSection(input.correction);
+  if (correctionSection) {
+    sections.push(correctionSection);
+  }
+
+  sections.push(
+    schemaSection.trim(),
+    "User request:",
+    input.request.trim(),
+    "Reminder: Apply any corrections precisely and ensure the final JSON satisfies every constraint before responding."
+  );
+
+  return sections
+    .filter((section) => section.length > 0)
+    .join("\n\n");
+}

--- a/src/scripts/prompts/index.ts
+++ b/src/scripts/prompts/index.ts
@@ -1,0 +1,10 @@
+export { buildActionPrompt } from "./actions";
+export type { ActionPromptInput } from "./actions";
+
+export { buildItemPrompt } from "./items";
+export type { ItemPromptInput } from "./items";
+
+export { buildActorPrompt } from "./actors";
+export type { ActorPromptInput } from "./actors";
+
+export type { CorrectionContext } from "./common";

--- a/src/scripts/prompts/items.ts
+++ b/src/scripts/prompts/items.ts
@@ -1,0 +1,63 @@
+import { ITEM_CATEGORIES, RARITIES, itemSchema, type SystemId } from "../schemas/index";
+import { type CorrectionContext, wrapPrompt } from "./common";
+
+export interface ItemPromptInput {
+  readonly systemId: SystemId;
+  readonly name: string;
+  readonly referenceText: string;
+  readonly slug?: string;
+  readonly correction?: CorrectionContext;
+}
+
+function buildItemSchemaSection(): string {
+  const categories = ITEM_CATEGORIES.join(", ");
+  const rarities = RARITIES.join(", ");
+  const schemaVersion = (itemSchema.properties.schema_version as { enum: readonly [number] }).enum[0];
+  const priceDefault = (itemSchema.properties.price as { default: number }).default;
+  const traitsDefault = JSON.stringify(
+    (itemSchema.properties.traits as { default: readonly string[] }).default
+  );
+  const descriptionDefault = (itemSchema.properties.description as { default: string }).default;
+  const imgDefault = (itemSchema.properties.img as { default: string }).default;
+  return [
+    "Item schema overview:",
+    `- schema_version: integer literal ${schemaVersion}.`,
+    "- type: string literal \"item\".",
+    "- slug: non-empty string.",
+    "- name: non-empty string.",
+    `- itemType: string enum (${categories}).`,
+    `- rarity: string enum (${rarities}).`,
+    "- level: integer >= 0.",
+    `- price: optional number >= 0; defaults to ${priceDefault}.`,
+    `- traits: optional array of non-empty strings; defaults to ${traitsDefault}.`,
+    `- description: optional string; defaults to "${descriptionDefault}".`,
+    `- img: optional string formatted as a URI reference; defaults to "${imgDefault}".`
+  ].join("\n");
+}
+
+function buildItemRequest(input: ItemPromptInput): string {
+  const parts: string[] = [
+    `Create a ${input.systemId} item entry named "${input.name}".`,
+    "Base your response on the following text:",
+    input.referenceText.trim()
+  ];
+
+  if (input.slug) {
+    parts.splice(1, 0, `Slug suggestion: ${input.slug}`);
+  }
+
+  return parts.join("\n\n");
+}
+
+export function buildItemPrompt(input: ItemPromptInput): string {
+  const request = buildItemRequest(input);
+  return wrapPrompt(
+    "Generate a Foundry VTT Item JSON document.",
+    buildItemSchemaSection(),
+    {
+      request,
+      systemId: input.systemId,
+      correction: input.correction
+    }
+  );
+}

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildActionPrompt,
+  buildActorPrompt,
+  buildItemPrompt,
+  type CorrectionContext
+} from "../src/scripts/prompts/index";
+
+const sampleReference = `Trigger: The foe moves.\nEffect: You strike twice.`;
+
+const correction: CorrectionContext = {
+  summary: "itemType must use the canonical enum values",
+  previous: {
+    schema_version: 1,
+    systemId: "pf2e",
+    type: "item",
+    slug: "bad-item",
+    name: "Bad Item",
+    itemType: "equipmint",
+    rarity: "common",
+    level: 1
+  }
+};
+
+test("buildActionPrompt renders the expected deterministic text", () => {
+  const prompt = buildActionPrompt({
+    systemId: "pf2e",
+    title: "Twin Slash",
+    slug: "twin-slash",
+    referenceText: sampleReference
+  });
+
+  const expected = `Generate a Foundry VTT Action JSON document.\n\nAlways respond with valid JSON matching the schema. Do not add commentary.\n\nSystem ID handling:\n- Allowed values:\n- pf2e\n- sf2e\n- Use the requested systemId: "pf2e".\n\nAction schema overview:\n- schema_version: integer literal 1.\n- type: string literal "action".\n- slug: non-empty string.\n- name: non-empty string.\n- actionType: string enum value (choose from: one-action, two-actions, three-actions, free, reaction).\n- description: non-empty string containing the full action rules.\n- traits: optional array of non-empty strings; defaults to [].\n- requirements: optional string; defaults to "".\n- img: optional string formatted as a URI reference; defaults to "".\n- rarity: optional string enum (common, uncommon, rare, unique); defaults to "common".\n\nUser request:\n\nCreate a pf2e action entry titled "Twin Slash".\n\nSlug suggestion: twin-slash\n\nUse the reference text verbatim where appropriate:\n\nTrigger: The foe moves.\nEffect: You strike twice.\n\nReminder: Apply any corrections precisely and ensure the final JSON satisfies every constraint before responding.`;
+
+  assert.equal(prompt, expected);
+});
+
+test("buildItemPrompt includes correction context to fix enum typos", () => {
+  const prompt = buildItemPrompt({
+    systemId: "pf2e",
+    name: "Healing Potion",
+    slug: "healing-potion",
+    referenceText: "A restorative concoction.",
+    correction
+  });
+
+  const expected = `Generate a Foundry VTT Item JSON document.\n\nAlways respond with valid JSON matching the schema. Do not add commentary.\n\nSystem ID handling:\n- Allowed values:\n- pf2e\n- sf2e\n- Use the requested systemId: "pf2e".\n\nCorrection context:\n- Reason: itemType must use the canonical enum values\n- Previous draft (update instead of recreating blindly):\n{\n  "schema_version": 1,\n  "systemId": "pf2e",\n  "type": "item",\n  "slug": "bad-item",\n  "name": "Bad Item",\n  "itemType": "equipmint",\n  "rarity": "common",\n  "level": 1\n}\n\nItem schema overview:\n- schema_version: integer literal 1.\n- type: string literal "item".\n- slug: non-empty string.\n- name: non-empty string.\n- itemType: string enum (armor, weapon, equipment, consumable, feat, spell, wand, staff, other).\n- rarity: string enum (common, uncommon, rare, unique).\n- level: integer >= 0.\n- price: optional number >= 0; defaults to 0.\n- traits: optional array of non-empty strings; defaults to [].\n- description: optional string; defaults to "".\n- img: optional string formatted as a URI reference; defaults to "".\n\nUser request:\n\nCreate a pf2e item entry named "Healing Potion".\n\nSlug suggestion: healing-potion\n\nBase your response on the following text:\n\nA restorative concoction.\n\nReminder: Apply any corrections precisely and ensure the final JSON satisfies every constraint before responding.`;
+
+  assert.equal(prompt, expected);
+});
+
+test("buildActorPrompt references the actor schema and defaults", () => {
+  const prompt = buildActorPrompt({
+    systemId: "sf2e",
+    name: "Android Sentry",
+    referenceText: "Guardian of the ancient vault."
+  });
+
+  const expected = `Generate a Foundry VTT Actor JSON document.\n\nAlways respond with valid JSON matching the schema. Do not add commentary.\n\nSystem ID handling:\n- Allowed values:\n- pf2e\n- sf2e\n- Use the requested systemId: "sf2e".\n\nActor schema overview:\n- schema_version: integer literal 1.\n- type: string literal "actor".\n- slug: non-empty string.\n- name: non-empty string.\n- actorType: string enum (character, npc, hazard, vehicle, familiar).\n- rarity: string enum (common, uncommon, rare, unique).\n- level: integer >= 0.\n- traits: optional array of non-empty strings; defaults to [].\n- languages: optional array of non-empty strings; defaults to [].\n- img: optional string formatted as a URI reference; defaults to "".\n\nUser request:\n\nCreate a sf2e actor entry named "Android Sentry".\n\nSummarise the following reference text into structured data:\n\nGuardian of the ancient vault.\n\nReminder: Apply any corrections precisely and ensure the final JSON satisfies every constraint before responding.`;
+
+  assert.equal(prompt, expected);
+});


### PR DESCRIPTION
## Summary
- add action, item, and actor prompt builders that render schema-driven instructions and correction reminders
- share prompt composition helpers to keep enum and default references in sync with the JSON schemas
- cover the builders with snapshot tests, including a correction case that exposes invalid enum usage

## Testing
- npx tsx --test tests/prompts.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e9c7dbfc9c832fa00e465107639bb2