### PR TITLE
feat: add action import helpers

### DIFF
--- a/src/scripts/mappers/import.ts
+++ b/src/scripts/mappers/import.ts
@@ -1,0 +1,443 @@
+import type { ActionSchemaData, ActorSchemaData, ItemSchemaData } from "../schemas";
+import { validate, formatError } from "../helpers/validation";
+
+const DEFAULT_ACTION_IMAGE = "systems/pf2e/icons/default-icons/action.svg" as const;
+const DEFAULT_ITEM_IMAGE = "systems/pf2e/icons/default-icons/item.svg" as const;
+const DEFAULT_ACTOR_IMAGE = "systems/pf2e/icons/default-icons/monster.svg" as const;
+
+const ACTION_TYPE_MAP: Record<ActionSchemaData["actionType"], { value: string; count: number | null }> = {
+  "one-action": { value: "one", count: 1 },
+  "two-actions": { value: "two", count: 2 },
+  "three-actions": { value: "three", count: 3 },
+  free: { value: "free", count: null },
+  reaction: { value: "reaction", count: null }
+};
+
+const GLYPH_MAP: Record<string, string> = {
+  "one-action": "1",
+  "two-actions": "2",
+  "three-actions": "3",
+  reaction: "r",
+  "free-action": "f",
+  free: "f"
+};
+
+interface PackIndexEntry {
+  _id?: string;
+  id?: string;
+  name?: string;
+  slug?: string | null;
+  system?: { slug?: string | null };
+}
+
+type ImportOptions = {
+  packId?: string;
+  folderId?: string;
+};
+
+type FoundryActionSource = {
+  name: string;
+  type: "action";
+  img: string;
+  system: {
+    slug: string;
+    description: { value: string };
+    traits: { value: string[]; rarity: string };
+    actionType: { value: string };
+    actions: { value: number | null };
+    requirements: { value: string };
+    source: { value: string };
+    rules: unknown[];
+  };
+  folder?: string;
+};
+
+type FoundryItemSource = {
+  name: string;
+  type: string;
+  img: string;
+  system: {
+    slug: string;
+    description: { value: string };
+    traits: { value: string[]; rarity: string };
+    level: { value: number };
+    price: { value: Record<string, number> };
+    source: { value: string };
+    rules: unknown[];
+  };
+  folder?: string;
+};
+
+type FoundryActorSource = {
+  name: string;
+  type: string;
+  img: string;
+  system: {
+    slug: string;
+    traits: { value: string[]; rarity: string; languages: { value: string[] } };
+    details: { level: { value: number }; source: { value: string } };
+  };
+  folder?: string;
+};
+
+function ensureValidAction(data: ActionSchemaData): void {
+  const validation = validate("action", data);
+  if (validation.ok) {
+    return;
+  }
+
+  const messages = validation.errors.map((error) => formatError(error));
+  throw new Error(`Action JSON failed validation:\n${messages.join("\n")}`);
+}
+
+function trimArray(values: readonly string[] | undefined): string[] {
+  if (!values?.length) {
+    return [];
+  }
+
+  return values.map((value) => value.trim()).filter((value) => value.length > 0);
+}
+
+function applyInlineFormatting(text: string): string {
+  const glyphPattern = /\[(one-action|two-actions|three-actions|reaction|free-action|free)\]/gi;
+  const boldPattern = /\*\*(.+?)\*\*/g;
+  const italicPattern = /(^|[^*])\*(?!\s)([^*]+?)\*/g;
+  const codePattern = /`([^`]+?)`/g;
+
+  let formatted = text;
+  formatted = formatted.replace(glyphPattern, (_match, group: string) => {
+    const token = group.toLowerCase();
+    const glyph = GLYPH_MAP[token];
+    return glyph ? `<span class="pf2-icon">${glyph}</span>` : _match;
+  });
+
+  formatted = formatted.replace(boldPattern, "<strong>$1</strong>");
+  formatted = formatted.replace(italicPattern, (_match, prefix: string, content: string) => `${prefix}<em>${content}</em>`);
+  formatted = formatted.replace(codePattern, "<code>$1</code>");
+
+  return formatted;
+}
+
+function buildParagraph(lines: string[]): string {
+  const content = lines.map((line) => applyInlineFormatting(line)).join("<br />");
+  return `<p>${content}</p>`;
+}
+
+function buildList(items: string[]): string {
+  const entries = items.map((item) => `<li>${applyInlineFormatting(item)}</li>`).join("");
+  return `<ul>${entries}</ul>`;
+}
+
+function toRichText(text: string | undefined): string {
+  const value = text?.trim();
+  if (!value) {
+    return "";
+  }
+
+  const lines = value.split(/\r?\n/);
+  const blocks: string[] = [];
+  let paragraph: string[] = [];
+  let listItems: string[] = [];
+
+  const flushParagraph = () => {
+    if (!paragraph.length) {
+      return;
+    }
+
+    blocks.push(buildParagraph(paragraph));
+    paragraph = [];
+  };
+
+  const flushList = () => {
+    if (!listItems.length) {
+      return;
+    }
+
+    blocks.push(buildList(listItems));
+    listItems = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    const bulletMatch = line.match(/^(?:[-*•]\s+)(.+)$/);
+    if (bulletMatch) {
+      flushParagraph();
+      listItems.push(bulletMatch[1].trim());
+      continue;
+    }
+
+    flushList();
+    paragraph.push(line);
+  }
+
+  flushParagraph();
+  flushList();
+
+  return blocks.join("");
+}
+
+function priceToCoins(price: number | undefined): Record<string, number> {
+  if (!price || price <= 0) {
+    return { pp: 0, gp: 0, sp: 0, cp: 0 }; 
+  }
+
+  const copperTotal = Math.round(price * 100);
+  const pp = Math.floor(copperTotal / 1000);
+  let remainder = copperTotal % 1000;
+  const gp = Math.floor(remainder / 100);
+  remainder %= 100;
+  const sp = Math.floor(remainder / 10);
+  remainder %= 10;
+  const cp = remainder;
+
+  return { pp, gp, sp, cp };
+}
+
+function matchesSlug(candidate: unknown, slug: string): boolean {
+  if (!candidate) {
+    return false;
+  }
+
+  const doc = candidate as { system?: { slug?: string | null }; slug?: string | null };
+  const value = doc.system?.slug ?? doc.slug;
+  return typeof value === "string" && value === slug;
+}
+
+function extractIndexEntries(index: unknown): PackIndexEntry[] {
+  if (!index) {
+    return [];
+  }
+
+  if (Array.isArray(index)) {
+    return index as PackIndexEntry[];
+  }
+
+  const result: PackIndexEntry[] = [];
+  const candidate = index as { values?: () => Iterable<unknown>; contents?: unknown };
+
+  if (typeof candidate.values === "function") {
+    for (const entry of candidate.values() as Iterable<PackIndexEntry>) {
+      result.push(entry);
+    }
+    return result;
+  }
+
+  const contents = (candidate as { contents?: unknown }).contents;
+  if (Array.isArray(contents)) {
+    return contents as PackIndexEntry[];
+  }
+
+  if (contents && typeof (contents as { values?: () => Iterable<unknown> }).values === "function") {
+    for (const entry of (contents as { values: () => Iterable<unknown> }).values() as Iterable<PackIndexEntry>) {
+      result.push(entry);
+    }
+  }
+
+  return result;
+}
+
+async function findPackDocument(pack: CompendiumCollection<Item>, slug: string): Promise<Item | undefined> {
+  const indexEntries = extractIndexEntries(pack.index);
+  let entry = indexEntries.find((item) => matchesSlug(item, slug));
+
+  if (!entry && typeof pack.getIndex === "function") {
+    const index = await pack.getIndex({ fields: ["slug", "system.slug"] });
+    const candidates = extractIndexEntries(index);
+    entry = candidates.find((item) => matchesSlug(item, slug));
+  }
+
+  if (!entry) {
+    return undefined;
+  }
+
+  const id = entry._id ?? entry.id;
+  if (!id) {
+    return undefined;
+  }
+
+  const existing = await pack.getDocument(id);
+  return existing ?? undefined;
+}
+
+function findWorldItem(slug: string): Item | undefined {
+  const collection = (game as Game).items as unknown;
+  if (!collection) {
+    return undefined;
+  }
+
+  const items = Array.isArray(collection)
+    ? collection
+    : (collection as { contents?: unknown; values?: () => Iterable<unknown>; find?: (predicate: (item: Item) => boolean) => Item | undefined });
+
+  if (typeof items.find === "function") {
+    const found = items.find((item: Item) => matchesSlug(item, slug));
+    if (found) {
+      return found;
+    }
+  }
+
+  const contentsCandidate = (items as { contents?: unknown }).contents;
+  if (Array.isArray(contentsCandidate)) {
+    for (const item of contentsCandidate as Item[]) {
+      if (matchesSlug(item, slug)) {
+        return item;
+      }
+    }
+  } else if (contentsCandidate && typeof (contentsCandidate as { values?: () => Iterable<Item> }).values === "function") {
+    for (const item of (contentsCandidate as { values: () => Iterable<Item> }).values()) {
+      if (matchesSlug(item, slug)) {
+        return item;
+      }
+    }
+  }
+
+  if (typeof (items as { values?: () => Iterable<Item> }).values === "function") {
+    for (const item of (items as { values: () => Iterable<Item> }).values()!) {
+      if (matchesSlug(item, slug)) {
+        return item;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function prepareActionSource(action: ActionSchemaData): FoundryActionSource {
+  const actionType = ACTION_TYPE_MAP[action.actionType];
+  const traits = trimArray(action.traits);
+  const description = toRichText(action.description);
+  const requirements = toRichText(action.requirements);
+
+  return {
+    name: action.name,
+    type: "action",
+    img: action.img?.trim() || DEFAULT_ACTION_IMAGE,
+    system: {
+      slug: action.slug,
+      description: { value: description },
+      traits: { value: traits, rarity: action.rarity ?? "common" },
+      actionType: { value: actionType.value },
+      actions: { value: actionType.count },
+      requirements: { value: requirements },
+      source: { value: "" },
+      rules: []
+    }
+  };
+}
+
+function prepareItemSource(item: ItemSchemaData): FoundryItemSource {
+  const traits = trimArray(item.traits);
+  const description = toRichText(item.description);
+
+  return {
+    name: item.name,
+    type: item.itemType,
+    img: item.img?.trim() || DEFAULT_ITEM_IMAGE,
+    system: {
+      slug: item.slug,
+      description: { value: description },
+      traits: { value: traits, rarity: item.rarity },
+      level: { value: item.level },
+      price: { value: priceToCoins(item.price) },
+      source: { value: "" },
+      rules: []
+    }
+  };
+}
+
+function prepareActorSource(actor: ActorSchemaData): FoundryActorSource {
+  const traits = trimArray(actor.traits);
+  const languages = trimArray(actor.languages);
+
+  return {
+    name: actor.name,
+    type: actor.actorType,
+    img: actor.img?.trim() || DEFAULT_ACTOR_IMAGE,
+    system: {
+      slug: actor.slug,
+      traits: {
+        value: traits,
+        rarity: actor.rarity,
+        languages: { value: languages }
+      },
+      details: {
+        level: { value: actor.level },
+        source: { value: "" }
+      }
+    }
+  };
+}
+
+export function toFoundryActionData(action: ActionSchemaData): FoundryActionSource {
+  return prepareActionSource(action);
+}
+
+export function toFoundryItemData(item: ItemSchemaData): FoundryItemSource {
+  return prepareItemSource(item);
+}
+
+export function toFoundryActorData(actor: ActorSchemaData): FoundryActorSource {
+  return prepareActorSource(actor);
+}
+
+export async function importAction(
+  json: ActionSchemaData,
+  options: ImportOptions = {}
+): Promise<Item> {
+  ensureValidAction(json);
+  const source = prepareActionSource(json);
+  const { packId, folderId } = options;
+
+  if (folderId) {
+    source.folder = folderId;
+  }
+
+  if (packId) {
+    const pack = game.packs?.get(packId) as CompendiumCollection<Item> | undefined;
+    if (!pack) {
+      throw new Error(`Pack with id "${packId}" was not found.`);
+    }
+
+    const existing = await findPackDocument(pack, json.slug);
+    if (existing) {
+      const updateData = { ...source } as Record<string, unknown>;
+      if (folderId) {
+        updateData.folder = folderId;
+      }
+
+      await existing.update(updateData);
+      return existing;
+    }
+
+    const imported = await pack.importDocument(source, { keepId: true });
+    if (!imported) {
+      throw new Error(`Failed to import action "${json.name}" into pack ${pack.collection}`);
+    }
+
+    return imported;
+  }
+
+  const existing = findWorldItem(json.slug);
+  if (existing) {
+    const updateData = { ...source } as Record<string, unknown>;
+    if (folderId) {
+      updateData.folder = folderId;
+    }
+
+    await existing.update(updateData);
+    return existing;
+  }
+
+  const created = await Item.create(source, { keepId: true });
+  if (!created) {
+    throw new Error(`Failed to create action "${json.name}" in the world.`);
+  }
+
+  return created;
+}

--- a/tests/import-mappers.test.ts
+++ b/tests/import-mappers.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import { importAction, toFoundryActionData } from "../src/scripts/mappers/import";
+import type { ActionSchemaData } from "../src/scripts/schemas";
+
+class MockItem {
+  public static nextId = 1;
+  public static created: MockItem[] = [];
+
+  public id: string;
+  public name: string;
+  public type: string;
+  public img: string;
+  public system: any;
+  public folder: string | null | undefined;
+
+  constructor(source: any) {
+    this.id = source._id ?? `MockItem.${MockItem.nextId++}`;
+    this.name = source.name;
+    this.type = source.type;
+    this.img = source.img;
+    this.system = JSON.parse(JSON.stringify(source.system ?? {}));
+    this.folder = source.folder ?? null;
+    MockItem.created.push(this);
+  }
+
+  static async create(source: any, _options?: any): Promise<MockItem> {
+    return new MockItem(source);
+  }
+
+  async update(changes: any): Promise<this> {
+    if (changes.name) this.name = changes.name;
+    if (changes.type) this.type = changes.type;
+    if (changes.img) this.img = changes.img;
+    if (changes.folder !== undefined) this.folder = changes.folder;
+    if (changes.system) {
+      this.system = JSON.parse(JSON.stringify(changes.system));
+    }
+    return this;
+  }
+}
+
+class MockPack {
+  public index: any[] = [];
+  private documents = new Map<string, MockItem>();
+
+  constructor(public collection: string) {}
+
+  async importDocument(source: any, _options?: any): Promise<MockItem> {
+    const document = new MockItem(source);
+    this.documents.set(document.id, document);
+    this.index.push({ _id: document.id, name: document.name, slug: document.system?.slug });
+    return document;
+  }
+
+  async getDocument(id: string): Promise<MockItem | undefined> {
+    return this.documents.get(id);
+  }
+
+  addDocument(doc: MockItem): void {
+    this.documents.set(doc.id, doc);
+    this.index.push({ _id: doc.id, name: doc.name, slug: doc.system?.slug });
+  }
+}
+
+class MockCollection<T extends { id: string }> extends Map<string, T> {
+  get contents(): T[] {
+    return Array.from(this.values());
+  }
+
+  find(predicate: (value: T) => boolean): T | undefined {
+    for (const value of this.values()) {
+      if (predicate(value)) return value;
+    }
+    return undefined;
+  }
+}
+
+const baseAction: ActionSchemaData = {
+  schema_version: 1,
+  systemId: "pf2e",
+  type: "action",
+  slug: "stunning-strike",
+  name: "Stunning Strike",
+  actionType: "two-actions",
+  traits: ["fighter", "press"],
+  requirements: "Wield a melee weapon",
+  description: "Deliver a crushing blow.\n\n• On a success, [reaction] is triggered.",
+  img: "icons/actions/stunning-strike.webp",
+  rarity: "uncommon"
+};
+
+beforeEach(() => {
+  MockItem.nextId = 1;
+  MockItem.created = [];
+  const packs = new Map<string, MockPack>();
+  const items = new MockCollection<MockItem>();
+
+  (globalThis as any).game = {
+    packs,
+    items,
+    user: { isGM: true }
+  } satisfies Partial<Game>;
+
+  Object.defineProperty(globalThis, "Item", {
+    configurable: true,
+    value: MockItem
+  });
+});
+
+test("toFoundryActionData converts canonical JSON into PF2e action data", () => {
+  const data = toFoundryActionData(baseAction);
+
+  assert.equal(data.name, "Stunning Strike");
+  assert.equal(data.type, "action");
+  assert.equal(data.system.slug, "stunning-strike");
+  assert.equal(data.system.traits.rarity, "uncommon");
+  assert.deepEqual(data.system.traits.value, ["fighter", "press"]);
+  assert.equal(data.system.actionType.value, "two");
+  assert.equal(data.system.actions.value, 2);
+  assert.match(data.system.description.value, /<p>Deliver a crushing blow\.<\/p><ul><li>On a success, <span class="pf2-icon">r<\/span> is triggered.<\/li><\/ul>/);
+  assert.equal(data.system.requirements.value, "<p>Wield a melee weapon<\/p>");
+});
+
+test("importAction updates an existing compendium entry with the same slug", async () => {
+  const pack = new MockPack("pf2e.actions");
+  const existing = new MockItem({
+    name: "Old Action",
+    type: "action",
+    img: "old.png",
+    system: { slug: "stunning-strike", description: { value: "<p>Old</p>" }, traits: { value: [], rarity: "common" }, actionType: { value: "one" }, actions: { value: 1 }, requirements: { value: "" }, source: { value: "" }, rules: [] }
+  });
+  pack.addDocument(existing);
+  (game.packs as Map<string, MockPack>).set("pf2e.actions", pack);
+
+  const result = await importAction(baseAction, { packId: "pf2e.actions", folderId: "folder-123" });
+
+  assert.strictEqual(result, existing);
+  assert.equal(existing.folder, "folder-123");
+  assert.equal(existing.system.description.value, toFoundryActionData(baseAction).system.description.value);
+});
+
+test("importAction creates a new compendium entry when none exists", async () => {
+  const pack = new MockPack("pf2e.actions");
+  (game.packs as Map<string, MockPack>).set("pf2e.actions", pack);
+
+  const result = await importAction(baseAction, { packId: "pf2e.actions" });
+
+  assert.equal(result.name, "Stunning Strike");
+  assert.equal(pack.index.length, 1);
+  assert.equal(result.system.slug, "stunning-strike");
+});
+
+test("importAction updates a world item when one with the slug is present", async () => {
+  const existing = new MockItem({
+    name: "Old Action",
+    type: "action",
+    img: "old.png",
+    system: { slug: "stunning-strike", description: { value: "<p>Old</p>" }, traits: { value: [], rarity: "common" }, actionType: { value: "one" }, actions: { value: 1 }, requirements: { value: "" }, source: { value: "" }, rules: [] }
+  });
+
+  (game.items as MockCollection<MockItem>).set(existing.id, existing);
+
+  const result = await importAction(baseAction, { folderId: "folder-999" });
+
+  assert.strictEqual(result, existing);
+  assert.equal(existing.folder, "folder-999");
+  assert.equal(existing.system.traits.rarity, "uncommon");
+});
+
+test("importAction creates a new world item when no match is found", async () => {
+  const result = await importAction(baseAction);
+  assert.equal(result.name, "Stunning Strike");
+  assert.equal(MockItem.created.length, 1);
+});
+
+test("importAction throws when the JSON payload is invalid", async () => {
+  await assert.rejects(
+    () =>
+      importAction({
+        ...baseAction,
+        description: ""
+      }),
+    /Action JSON failed validation/
+  );
+});


### PR DESCRIPTION
## Summary
- add Foundry import mappers that rebuild PF2e document data from canonical JSON
- implement importAction helper to validate and upsert actions into compendia or world collections
- cover glyph/rich text conversions and import flows with Foundry test doubles

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68e9cf9cd95c832f96f0043e69b87e7e