### PR TITLE
Add batch export and generation flows with UI hooks

### DIFF
--- a/src/scripts/flows/batch-ui.ts
+++ b/src/scripts/flows/batch-ui.ts
@@ -1,0 +1,198 @@
+import { CONSTANTS } from "../constants";
+import {
+  collectFailureMessages,
+  exportSelectedEntities,
+  generateAndImportBatch,
+  type GenerationBatchEntry,
+  type GenerationBatchOptions,
+  type GenerationBatchResult,
+} from "./batch";
+import type { EntityType } from "../schemas";
+
+export async function runExportSelectionFlow(): Promise<void> {
+  try {
+    const result = exportSelectedEntities();
+    if (!result.entries.length) {
+      ui.notifications?.warn(`${CONSTANTS.MODULE_NAME} | No controlled tokens or directory selections to export.`);
+      return;
+    }
+
+    const prefix = `${CONSTANTS.MODULE_NAME} |`;
+    const failures = collectFailureMessages(result.entries);
+    const summary = result.summary;
+
+    if (result.successCount > 0) {
+      let message = summary;
+      try {
+        await navigator.clipboard.writeText(result.json);
+        message = `${summary} Copied JSON to clipboard.`;
+      } catch (error) {
+        console.warn(`${CONSTANTS.MODULE_NAME} | Clipboard copy failed`, error);
+      }
+      ui.notifications?.info(`${prefix} ${message}`);
+      console.info(`${CONSTANTS.MODULE_NAME} | Exported canonical JSON`, JSON.parse(result.json));
+    } else {
+      ui.notifications?.warn(`${prefix} ${summary}`);
+    }
+
+    if (failures.length) {
+      ui.notifications?.warn(`${prefix} ${failures.length} selection(s) failed. Check console for details.`);
+      console.warn(`${CONSTANTS.MODULE_NAME} | Export failures`, failures);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ui.notifications?.error(`${CONSTANTS.MODULE_NAME} | Export failed: ${message}`);
+    console.error(`${CONSTANTS.MODULE_NAME} | Export selection failed`, error);
+  }
+}
+
+export async function runBatchGenerationFlow(): Promise<void> {
+  const request = await promptBatchGeneration();
+  if (!request) {
+    return;
+  }
+
+  try {
+    const result = await generateAndImportBatch(request);
+    reportGenerationResult(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ui.notifications?.error(`${CONSTANTS.MODULE_NAME} | Batch generation failed: ${message}`);
+    console.error(`${CONSTANTS.MODULE_NAME} | Batch generation failed`, error);
+  }
+}
+
+async function promptBatchGeneration(): Promise<GenerationBatchOptions<EntityType> | null> {
+  const content = `
+    <form class="handy-dandy-batch-form">
+      <div class="form-group">
+        <label>Entity Type</label>
+        <select name="entityType">
+          <option value="action">Action</option>
+          <option value="item">Item</option>
+          <option value="actor">Actor</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label>Prompt Inputs (JSON Array)</label>
+        <textarea name="payload" rows="8" style="width: 100%;"></textarea>
+      </div>
+      <div class="form-group">
+        <label>Compendium Pack ID (optional)</label>
+        <input type="text" name="packId" />
+      </div>
+      <div class="form-group">
+        <label>Folder ID (optional)</label>
+        <input type="text" name="folderId" />
+      </div>
+      <div class="form-group">
+        <label>Seed (optional)</label>
+        <input type="number" name="seed" />
+      </div>
+      <div class="form-group">
+        <label>Max Attempts (optional)</label>
+        <input type="number" name="maxAttempts" min="1" />
+      </div>
+    </form>
+  `;
+
+  const response = await Dialog.prompt<{
+    entityType: string;
+    payload: string;
+    packId: string;
+    folderId: string;
+    seed: string;
+    maxAttempts: string;
+  } | null>({
+    title: `${CONSTANTS.MODULE_NAME} | Batch Generate`,
+    content,
+    label: "Run Batch",
+    callback: (html) => {
+      const form = html[0]?.querySelector("form");
+      if (!form) {
+        return null;
+      }
+
+      const formData = new FormData(form as HTMLFormElement);
+      const entityType = String(formData.get("entityType") ?? "");
+      const payload = String(formData.get("payload") ?? "");
+      const packId = String(formData.get("packId") ?? "").trim();
+      const folderId = String(formData.get("folderId") ?? "").trim();
+      const seed = String(formData.get("seed") ?? "").trim();
+      const maxAttempts = String(formData.get("maxAttempts") ?? "").trim();
+
+      return { entityType, payload, packId, folderId, seed, maxAttempts };
+    },
+    options: { jQuery: true },
+  });
+
+  if (!response) {
+    return null;
+  }
+
+  const type = sanitizeEntityType(response.entityType);
+  if (!type) {
+    ui.notifications?.error(`${CONSTANTS.MODULE_NAME} | Invalid entity type.`);
+    return null;
+  }
+
+  let inputs: unknown;
+  try {
+    inputs = response.payload ? JSON.parse(response.payload) : [];
+  } catch (error) {
+    ui.notifications?.error(`${CONSTANTS.MODULE_NAME} | Failed to parse JSON: ${(error as Error).message}`);
+    return null;
+  }
+
+  if (!Array.isArray(inputs)) {
+    ui.notifications?.error(`${CONSTANTS.MODULE_NAME} | Prompt input must be an array.`);
+    return null;
+  }
+
+  return {
+    type,
+    inputs: inputs as GenerationBatchOptions<EntityType>["inputs"],
+    packId: response.packId || undefined,
+    folderId: response.folderId || undefined,
+    seed: parseOptionalNumber(response.seed),
+    maxAttempts: parseOptionalNumber(response.maxAttempts),
+  } satisfies GenerationBatchOptions<EntityType>;
+}
+
+function parseOptionalNumber(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function sanitizeEntityType(value: string): EntityType | null {
+  switch (value) {
+    case "action":
+    case "item":
+    case "actor":
+      return value;
+    default:
+      return null;
+  }
+}
+
+function reportGenerationResult(result: GenerationBatchResult<EntityType>): void {
+  const prefix = `${CONSTANTS.MODULE_NAME} |`;
+  const summary = result.summary;
+  const failures = collectFailureMessages(result.entries as GenerationBatchEntry<EntityType>[]);
+
+  if (result.successCount > 0) {
+    ui.notifications?.info(`${prefix} ${summary}`);
+  } else {
+    ui.notifications?.warn(`${prefix} ${summary}`);
+  }
+
+  if (failures.length) {
+    ui.notifications?.warn(`${prefix} ${failures.length} batch item(s) failed. Check console for details.`);
+    console.warn(`${CONSTANTS.MODULE_NAME} | Batch generation failures`, failures);
+  }
+}

--- a/src/scripts/flows/batch.ts
+++ b/src/scripts/flows/batch.ts
@@ -1,0 +1,521 @@
+import { fromFoundryAction, fromFoundryActor, fromFoundryItem } from "../mappers/export";
+import { importAction } from "../mappers/import";
+import type {
+  ActionSchemaData,
+  ActorSchemaData,
+  EntityType,
+  ItemSchemaData,
+} from "../schemas";
+import type {
+  ActionPromptInput,
+  ActorPromptInput,
+  ItemPromptInput,
+} from "../prompts";
+
+type CanonicalEntityMap = {
+  action: ActionSchemaData;
+  item: ItemSchemaData;
+  actor: ActorSchemaData;
+};
+
+type PromptInputMap = {
+  action: ActionPromptInput;
+  item: ItemPromptInput;
+  actor: ActorPromptInput;
+};
+
+type BatchEntityType = EntityType | "unknown";
+
+type BatchStatus = "success" | "failure";
+
+export interface ExportBatchEntry<T extends BatchEntityType = BatchEntityType> {
+  readonly type: T;
+  readonly name: string;
+  readonly id?: string;
+  readonly uuid?: string;
+  readonly status: BatchStatus;
+  readonly data?: T extends EntityType ? CanonicalEntityMap[T] : never;
+  readonly error?: Error;
+}
+
+export interface ExportSelectionOptions {
+  readonly documents?: Iterable<unknown>;
+}
+
+export interface ExportSelectionResult {
+  readonly entries: ExportBatchEntry[];
+  readonly successCount: number;
+  readonly failureCount: number;
+  readonly summary: string;
+  readonly json: string;
+}
+
+export interface GenerationBatchEntry<T extends EntityType> {
+  readonly type: T;
+  readonly input: PromptInputMap[T];
+  readonly name: string;
+  readonly status: BatchStatus;
+  readonly data?: CanonicalEntityMap[T];
+  readonly documentUuid?: string;
+  readonly error?: Error;
+}
+
+export interface GenerationBatchOptions<T extends EntityType> {
+  readonly type: T;
+  readonly inputs: readonly PromptInputMap[T][];
+  readonly packId?: string;
+  readonly folderId?: string;
+  readonly seed?: number;
+  readonly maxAttempts?: number;
+  readonly dependencies?: GenerationDependencyOverrides;
+}
+
+export interface GenerationBatchResult<T extends EntityType> {
+  readonly type: T;
+  readonly entries: GenerationBatchEntry<T>[];
+  readonly successCount: number;
+  readonly failureCount: number;
+  readonly summary: string;
+}
+
+interface GeneratorMap {
+  action: (input: ActionPromptInput, options?: BoundGenerationOptions) => Promise<ActionSchemaData>;
+  item: (input: ItemPromptInput, options?: BoundGenerationOptions) => Promise<ItemSchemaData>;
+  actor: (input: ActorPromptInput, options?: BoundGenerationOptions) => Promise<ActorSchemaData>;
+}
+
+interface ImporterMap {
+  action: (json: ActionSchemaData, options?: ImporterOptions) => Promise<ClientDocument>;
+  item: (json: ItemSchemaData, options?: ImporterOptions) => Promise<ClientDocument>;
+  actor: (json: ActorSchemaData, options?: ImporterOptions) => Promise<ClientDocument>;
+}
+
+interface BoundGenerationOptions {
+  seed?: number;
+  maxAttempts?: number;
+}
+
+interface ImporterOptions {
+  packId?: string;
+  folderId?: string;
+}
+
+export interface GenerationDependencyOverrides {
+  readonly generators?: Partial<GeneratorMap>;
+  readonly importers?: Partial<ImporterMap>;
+}
+
+export function formatBatchSummary(
+  noun: string,
+  total: number,
+  successCount: number,
+  failureCount: number,
+): string {
+  if (!total) {
+    return `No ${noun} processed.`;
+  }
+
+  if (!failureCount) {
+    return `Processed ${total} ${noun}: all succeeded.`;
+  }
+
+  if (!successCount) {
+    return `Processed ${total} ${noun}: all failed.`;
+  }
+
+  return `Processed ${total} ${noun}: ${successCount} succeeded, ${failureCount} failed.`;
+}
+
+export function collectFailureMessages(entries: readonly { status: BatchStatus; name: string; error?: Error }[]): string[] {
+  return entries
+    .filter((entry) => entry.status === "failure")
+    .map((entry) => `${entry.name}: ${entry.error?.message ?? "Unknown error"}`);
+}
+
+export function exportSelectedEntities(options: ExportSelectionOptions = {}): ExportSelectionResult {
+  const documents = Array.from(options.documents ?? collectCurrentSelection());
+  if (!documents.length) {
+    return {
+      entries: [],
+      successCount: 0,
+      failureCount: 0,
+      summary: formatBatchSummary("documents", 0, 0, 0),
+      json: "[]",
+    } satisfies ExportSelectionResult;
+  }
+
+  const entries: ExportBatchEntry[] = [];
+  for (const doc of documents) {
+    entries.push(convertDocument(doc));
+  }
+
+  const successes = entries.filter((entry) => entry.status === "success");
+  const json = JSON.stringify(successes.map((entry) => entry.data), null, 2);
+  const successCount = successes.length;
+  const failureCount = entries.length - successCount;
+
+  return {
+    entries,
+    successCount,
+    failureCount,
+    summary: formatBatchSummary("documents", entries.length, successCount, failureCount),
+    json,
+  } satisfies ExportSelectionResult;
+}
+
+export async function generateAndImportBatch<T extends EntityType>(
+  options: GenerationBatchOptions<T>,
+): Promise<GenerationBatchResult<T>> {
+  const {
+    type,
+    inputs,
+    packId,
+    folderId,
+    seed,
+    maxAttempts,
+    dependencies = {},
+  } = options;
+
+  const generator = resolveGenerator(type, dependencies.generators);
+  const importer = resolveImporter(type, dependencies.importers);
+  const batchEntries: GenerationBatchEntry<T>[] = [];
+
+  for (const input of inputs) {
+    const label = inferInputName(type, input as PromptInputMap[T]);
+    try {
+      const data = await generator(input as PromptInputMap[T], { seed, maxAttempts });
+      const document = await importer(data as CanonicalEntityMap[T], { packId, folderId });
+      batchEntries.push({
+        type,
+        input: input as PromptInputMap[T],
+        name: typeof (data as { name?: string }).name === "string" && (data as { name?: string }).name?.trim()
+          ? (data as { name: string }).name
+          : label,
+        status: "success",
+        data: data as CanonicalEntityMap[T],
+        documentUuid: typeof document?.uuid === "string" ? document.uuid : undefined,
+      });
+    } catch (error) {
+      batchEntries.push({
+        type,
+        input: input as PromptInputMap[T],
+        name: label,
+        status: "failure",
+        error: normalizeError(error),
+      });
+    }
+  }
+
+  const successCount = batchEntries.filter((entry) => entry.status === "success").length;
+  const failureCount = batchEntries.length - successCount;
+  const summary = formatBatchSummary(nounForType(type), batchEntries.length, successCount, failureCount);
+
+  return {
+    type,
+    entries: batchEntries,
+    successCount,
+    failureCount,
+    summary,
+  } satisfies GenerationBatchResult<T>;
+}
+
+function nounForType(type: EntityType): string {
+  switch (type) {
+    case "action":
+      return "actions";
+    case "item":
+      return "items";
+    case "actor":
+      return "actors";
+    default:
+      return "entries";
+  }
+}
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if (typeof error === "string") {
+    return new Error(error);
+  }
+
+  try {
+    return new Error(JSON.stringify(error));
+  } catch (_jsonError) {
+    return new Error(String(error));
+  }
+}
+
+function resolveGenerator<T extends EntityType>(
+  type: T,
+  overrides: GenerationDependencyOverrides["generators"],
+): GeneratorMap[T] {
+  if (overrides?.[type]) {
+    return overrides[type] as GeneratorMap[T];
+  }
+
+  const generation = game.handyDandy?.generation;
+  if (!generation) {
+    throw new Error("Handy Dandy generation helpers are unavailable.");
+  }
+
+  const generator = generation[`generate${capitalize(type)}` as const];
+  if (!generator) {
+    throw new Error(`No generator available for ${type} entries.`);
+  }
+
+  return generator as GeneratorMap[T];
+}
+
+function resolveImporter<T extends EntityType>(
+  type: T,
+  overrides: GenerationDependencyOverrides["importers"],
+): ImporterMap[T] {
+  if (overrides?.[type]) {
+    return overrides[type] as ImporterMap[T];
+  }
+
+  switch (type) {
+    case "action":
+      return importAction as unknown as ImporterMap[T];
+    default:
+      throw new Error(`No importer configured for ${type} entries.`);
+  }
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function collectCurrentSelection(): unknown[] {
+  const documents: unknown[] = [];
+  const seen = new Set<string>();
+
+  const add = (doc: any) => {
+    if (!doc) {
+      return;
+    }
+
+    const uuid = typeof doc.uuid === "string" ? doc.uuid : undefined;
+    if (uuid) {
+      if (seen.has(uuid)) {
+        return;
+      }
+      seen.add(uuid);
+    }
+
+    documents.push(doc);
+  };
+
+  const controlled = canvas?.tokens?.controlled ?? [];
+  for (const token of controlled as any[]) {
+    add(token?.actor);
+  }
+
+  const actorTab = ui.sidebar?.tabs?.actors as SidebarDirectory | undefined;
+  for (const actor of collectDirectorySelection(actorTab)) {
+    add(actor);
+  }
+
+  const itemTab = ui.sidebar?.tabs?.items as SidebarDirectory | undefined;
+  for (const item of collectDirectorySelection(itemTab)) {
+    add(item);
+  }
+
+  return documents;
+}
+
+function inferInputName<T extends EntityType>(type: T, input: PromptInputMap[T]): string {
+  switch (type) {
+    case "action": {
+      const actionInput = input as ActionPromptInput;
+      return actionInput.title?.trim() || actionInput.slug?.trim() || "Unnamed";
+    }
+    case "item": {
+      const itemInput = input as ItemPromptInput;
+      return itemInput.name?.trim() || itemInput.slug?.trim() || "Unnamed";
+    }
+    case "actor": {
+      const actorInput = input as ActorPromptInput;
+      return actorInput.name?.trim() || actorInput.slug?.trim() || "Unnamed";
+    }
+    default:
+      return "Unnamed";
+  }
+}
+
+function collectDirectorySelection(tab: SidebarDirectory | undefined): unknown[] {
+  if (!tab) {
+    return [];
+  }
+
+  const collection = (tab as { collection?: Collection<ClientDocument> }).collection;
+  if (!collection || typeof collection.get !== "function") {
+    return [];
+  }
+
+  const element = (tab as { element?: JQuery | HTMLElement | null }).element;
+  const root = resolveHTMLElement(element);
+  if (!root) {
+    return [];
+  }
+
+  const selected = root.querySelectorAll<HTMLElement>(".directory-item.active[data-document-id]");
+  const documents: ClientDocument[] = [];
+  for (const entry of selected) {
+    const id = entry.dataset.documentId;
+    if (!id) {
+      continue;
+    }
+
+    const document = collection.get(id);
+    if (document) {
+      documents.push(document);
+    }
+  }
+
+  return documents;
+}
+
+function resolveHTMLElement(candidate: JQuery | HTMLElement | null | undefined): HTMLElement | null {
+  if (!candidate) {
+    return null;
+  }
+
+  if (candidate instanceof HTMLElement) {
+    return candidate;
+  }
+
+  const maybeJQuery = candidate as JQuery;
+  if (typeof maybeJQuery.get === "function") {
+    const element = maybeJQuery.get(0);
+    return element instanceof HTMLElement ? element : null;
+  }
+
+  return null;
+}
+
+function convertDocument(document: unknown): ExportBatchEntry {
+  const base = buildEntryBase(document);
+  if (!base) {
+    return {
+      type: "unknown",
+      name: "Unknown Document",
+      status: "failure",
+      error: new Error("Unsupported document selection."),
+    } satisfies ExportBatchEntry;
+  }
+
+  const { doc, type } = base;
+
+  try {
+    switch (type) {
+      case "actor": {
+        const source = doc.toObject?.() ?? doc;
+        const data = fromFoundryActor(source as any);
+        return { ...base.meta, type, status: "success", data } satisfies ExportBatchEntry;
+      }
+      case "action": {
+        const source = doc.toObject?.() ?? doc;
+        const data = fromFoundryAction(source as any);
+        return { ...base.meta, type, status: "success", data } satisfies ExportBatchEntry;
+      }
+      case "item": {
+        const source = doc.toObject?.() ?? doc;
+        const data = fromFoundryItem(source as any);
+        return { ...base.meta, type, status: "success", data } satisfies ExportBatchEntry;
+      }
+      default:
+        return {
+          ...base.meta,
+          type,
+          status: "failure",
+          error: new Error(`Unsupported document type: ${type}`),
+        } satisfies ExportBatchEntry;
+    }
+  } catch (error) {
+    return {
+      ...base.meta,
+      type,
+      status: "failure",
+      error: normalizeError(error),
+    } satisfies ExportBatchEntry;
+  }
+}
+
+function buildEntryBase(document: unknown):
+  | { doc: any; type: BatchEntityType; meta: Omit<ExportBatchEntry, "type" | "status" | "data" | "error"> }
+  | null {
+  if (!document || typeof document !== "object") {
+    return null;
+  }
+
+  const doc = document as { documentName?: string; type?: string; name?: string; id?: string; uuid?: string; actor?: unknown };
+  const name = typeof doc.name === "string" && doc.name.trim() ? doc.name : "Unnamed";
+  const id = typeof doc.id === "string" ? doc.id : undefined;
+  const uuid = typeof doc.uuid === "string" ? doc.uuid : undefined;
+
+  if (isTokenDocument(doc)) {
+    const actor = (doc as { actor?: unknown }).actor;
+    if (!actor) {
+      return {
+        doc,
+        type: "actor",
+        meta: { name, id, uuid },
+      };
+    }
+
+    return buildEntryBase(actor);
+  }
+
+  if (isActorDocument(doc)) {
+    return {
+      doc,
+      type: "actor",
+      meta: { name, id, uuid },
+    };
+  }
+
+  if (isItemDocument(doc)) {
+    if (isActionItem(doc)) {
+      return {
+        doc,
+        type: "action",
+        meta: { name, id, uuid },
+      };
+    }
+
+    return {
+      doc,
+      type: "item",
+      meta: { name, id, uuid },
+    };
+  }
+
+  return {
+    doc,
+    type: "unknown",
+    meta: { name, id, uuid },
+  };
+}
+
+function isActorDocument(doc: { documentName?: string }): boolean {
+  return doc.documentName === "Actor";
+}
+
+function isItemDocument(doc: { documentName?: string }): boolean {
+  return doc.documentName === "Item";
+}
+
+function isActionItem(doc: { type?: string }): boolean {
+  return (doc.type ?? "").toLowerCase() === "action";
+}
+
+function isTokenDocument(doc: { documentName?: string }): boolean {
+  return doc.documentName === "Token" || doc.documentName === "TokenDocument";
+}
+
+type SidebarDirectory = { element?: JQuery | HTMLElement | null; collection?: Collection<ClientDocument> };
+

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -15,6 +15,7 @@ import {
 } from "./generation";
 import type { ActionPromptInput, ActorPromptInput, ItemPromptInput } from "./prompts";
 import type { ActionSchemaData, ActorSchemaData, ItemSchemaData } from "./schemas";
+import { exportSelectedEntities, generateAndImportBatch } from "./flows/batch";
 
 type GeneratorFunction<TInput, TResult> = (
   input: TInput,
@@ -71,8 +72,12 @@ declare global {
       },
       applications: {
         schemaTool: SchemaTool,
-        dataEntryTool: DataEntryTool
-      }
+        dataEntryTool: DataEntryTool,
+      },
+      flows: {
+        exportSelection: typeof exportSelectedEntities;
+        generateBatch: typeof generateAndImportBatch;
+      };
     };
   }
 }
@@ -104,8 +109,12 @@ Hooks.once("setup", () => {
     },
     applications: {
       schemaTool: new SchemaTool,
-      dataEntryTool: new DataEntryTool
-    }
+      dataEntryTool: new DataEntryTool,
+    },
+    flows: {
+      exportSelection: exportSelectedEntities,
+      generateBatch: generateAndImportBatch,
+    },
   };
 });
 

--- a/src/scripts/setup/sidebarButtons.ts
+++ b/src/scripts/setup/sidebarButtons.ts
@@ -1,14 +1,15 @@
 import { CONSTANTS } from "../constants";
+import { runBatchGenerationFlow, runExportSelectionFlow } from "../flows/batch-ui";
 import { SchemaTool } from "../tools/schema-tool";
 
-export function insertSidebarButtons(controls: SceneControl[]) {
-    const handyGroup: SceneControl = {
+export function insertSidebarButtons(controls: SceneControl[]): void {
+  const handyGroup: SceneControl = {
     name: "handy-dandy",
     title: "Handy Dandy Tools",
     icon: "fas fa-screwdriver-wrench",
-    layer: "controls",                // Any existing layer is fine
+    layer: "controls", // Any existing layer is fine
     visible: true,
-    activeTool: "schema-tool",             // Mandatory in v12 :contentReference[oaicite:0]{index=0}
+    activeTool: "schema-tool", // Mandatory in v12 :contentReference[oaicite:0]{index=0}
     tools: <SceneControlTool[]>[
       {
         name: "schema-tool",
@@ -37,8 +38,27 @@ export function insertSidebarButtons(controls: SceneControl[]) {
           }
           game.handyDandy.applications.dataEntryTool.render(true);
         }
+      },
+      {
+        name: "export-selection",
+        title: "Export Selection",
+        icon: "fas fa-file-export",
+        button: true,
+        onClick: () => {
+          void runExportSelectionFlow();
+        }
+      },
+      {
+        name: "batch-generate",
+        title: "Batch Generate & Import",
+        icon: "fas fa-diagram-project",
+        button: true,
+        onClick: () => {
+          void runBatchGenerationFlow();
+        }
       }
     ]
   };
-  controls.push(handyGroup);          // Mutate in-place per docs :contentReference[oaicite:1]{index=1}
+
+  controls.push(handyGroup); // Mutate in-place per docs :contentReference[oaicite:1]{index=1}
 }

--- a/src/scripts/tools/schema-tool.ts
+++ b/src/scripts/tools/schema-tool.ts
@@ -1,5 +1,6 @@
 import { CONSTANTS } from "../constants";
 import { flattenSchema, listDocumentConstructors, getDocumentSchema } from "../helpers/utils";
+import { runBatchGenerationFlow, runExportSelectionFlow } from "../flows/batch-ui";
 
 /**
  * A lightweight window that lets the GM choose a Foundry document type
@@ -47,6 +48,14 @@ export class SchemaTool extends Application {
       const text = (ev.currentTarget as HTMLElement).dataset["path"] ?? "";
       navigator.clipboard.writeText(text);
       ui.notifications?.info(`Copied path ${text}`);
+    });
+
+    html.find<HTMLButtonElement>("button[data-action='export-selection']").on("click", () => {
+      void runExportSelectionFlow();
+    });
+
+    html.find<HTMLButtonElement>("button[data-action='batch-generate']").on("click", () => {
+      void runBatchGenerationFlow();
     });
   }
 }

--- a/src/templates/schema-tool.hbs
+++ b/src/templates/schema-tool.hbs
@@ -8,6 +8,11 @@
     </select>
   </div>
 
+  <div class="schema-tool-actions">
+    <button type="button" data-action="export-selection"><i class="fas fa-file-export"></i> Export Selection</button>
+    <button type="button" data-action="batch-generate"><i class="fas fa-diagram-project"></i> Batch Generate</button>
+  </div>
+
   <hr>
 
   <section class="schema-list">

--- a/tests/flows-batch.test.ts
+++ b/tests/flows-batch.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  collectFailureMessages,
+  exportSelectedEntities,
+  formatBatchSummary,
+  generateAndImportBatch,
+  type GenerationBatchOptions,
+} from "../src/scripts/flows/batch";
+import type { ActionPromptInput } from "../src/scripts/prompts";
+import type { ActionSchemaData } from "../src/scripts/schemas";
+
+function createActionDocument(overrides: Partial<Record<string, unknown>> = {}): any {
+  return {
+    documentName: "Item",
+    name: "Power Attack",
+    type: "action",
+    toObject: () => ({
+      name: "Power Attack",
+      type: "action",
+      img: "icons/actions/power-attack.webp",
+      system: {
+        slug: "power-attack",
+        description: { value: "<p>Strike with force.</p>" },
+        traits: { value: ["attack"], rarity: "common" },
+        actionType: { value: "one" },
+        requirements: { value: "Wield a melee weapon." }
+      }
+    }),
+    ...overrides,
+  };
+}
+
+function createItemDocument(): any {
+  return {
+    documentName: "Item",
+    name: "Resonant Blade",
+    type: "weapon",
+    toObject: () => ({
+      name: "Resonant Blade",
+      type: "weapon",
+      img: "systems/pf2e/icons/default-icons/weapon.svg",
+      system: {
+        description: { value: "<p>Shiny blade.</p>" },
+        level: { value: 2 },
+        traits: { value: ["magical"], rarity: "uncommon" },
+        price: { value: { gp: 12 } }
+      }
+    })
+  };
+}
+
+test("exportSelectedEntities returns canonical JSON and failure details", () => {
+  const successAction = createActionDocument();
+  const successItem = createItemDocument();
+  const failingDoc = createActionDocument({
+    name: "Broken",
+    toObject: () => {
+      throw new Error("Document access failed");
+    }
+  });
+
+  const result = exportSelectedEntities({ documents: [successAction, successItem, failingDoc] });
+
+  assert.equal(result.entries.length, 3);
+  assert.equal(result.successCount, 2);
+  assert.equal(result.failureCount, 1);
+  assert.equal(result.summary, "Processed 3 documents: 2 succeeded, 1 failed.");
+
+  const exported = JSON.parse(result.json) as unknown[];
+  assert.equal(exported.length, 2);
+  assert.ok(exported.every((entry) => typeof entry === "object" && entry !== null));
+
+  const failures = collectFailureMessages(result.entries);
+  assert.deepEqual(failures, ["Broken: Document access failed"]);
+});
+
+test("generateAndImportBatch aggregates mixed success and failure", async () => {
+  const inputs: ActionPromptInput[] = [
+    {
+      systemId: "pf2e",
+      title: "Sure Strike",
+      referenceText: "Strike true.",
+    },
+    {
+      systemId: "pf2e",
+      title: "Failed Draft",
+      referenceText: "This will fail generation.",
+    },
+    {
+      systemId: "pf2e",
+      title: "Import Trouble",
+      referenceText: "Cause import failure.",
+      slug: "import-error",
+    },
+  ];
+
+  const generator = async (input: ActionPromptInput): Promise<ActionSchemaData> => {
+    if (input.title === "Failed Draft") {
+      throw new Error("Generation failed for Failed Draft");
+    }
+
+    const slug = input.slug ?? input.title.toLowerCase().replace(/\s+/g, "-");
+    return {
+      schema_version: 1,
+      systemId: input.systemId,
+      type: "action",
+      slug,
+      name: input.title,
+      actionType: "one-action",
+      requirements: "",
+      description: "Strike with precision.",
+      rarity: "common",
+      traits: [],
+    } satisfies ActionSchemaData;
+  };
+
+  const importer = async (data: ActionSchemaData): Promise<any> => {
+    if (data.slug === "import-error") {
+      throw new Error("Import failed for import-error");
+    }
+
+    return { uuid: `Item.${data.slug}` } as any;
+  };
+
+  const options: GenerationBatchOptions<"action"> = {
+    type: "action",
+    inputs,
+    dependencies: {
+      generators: { action: generator },
+      importers: { action: importer },
+    },
+  };
+
+  const result = await generateAndImportBatch(options);
+
+  assert.equal(result.entries.length, 3);
+  assert.equal(result.successCount, 1);
+  assert.equal(result.failureCount, 2);
+  assert.equal(result.summary, "Processed 3 actions: 1 succeeded, 2 failed.");
+
+  const failures = collectFailureMessages(result.entries);
+  assert.deepEqual(failures, [
+    "Failed Draft: Generation failed for Failed Draft",
+    "Import Trouble: Import failed for import-error",
+  ]);
+
+  const summaryAllSuccess = formatBatchSummary("actions", 2, 2, 0);
+  assert.equal(summaryAllSuccess, "Processed 2 actions: all succeeded.");
+});


### PR DESCRIPTION
## Summary
- add batch helpers for exporting current selections and orchestrating generation/import runs with per-item results
- expose new flows through shared UI helpers used by the Handy Dandy scene controls and schema tool
- cover mixed success and failure scenarios with integration tests for batch reporting

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68e9d1175f84832faa2e8bb16d4ada10