### PR TITLE
Add developer console logging and ensureValid repair retry support

### DIFF
--- a/src/scripts/dev/developer-console.ts
+++ b/src/scripts/dev/developer-console.ts
@@ -1,0 +1,197 @@
+import { CONSTANTS } from "../constants";
+import type { ValidatorKey } from "../schemas";
+
+type GPTInteractionMethod = "structured" | "tool";
+
+export interface GPTInteractionLogPayload {
+  promptHash: string;
+  schemaName: string;
+  model: string;
+  method: GPTInteractionMethod;
+  durationMs: number;
+  startedAt: number;
+  success: boolean;
+  usage?: GPTUsageMetrics;
+  error?: string;
+}
+
+export interface GPTUsageMetrics {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
+interface GPTInteractionLogEntry {
+  readonly id: string;
+  readonly timestamp: string;
+  readonly promptHash: string;
+  readonly schemaName: string;
+  readonly model: string;
+  readonly method: GPTInteractionMethod;
+  readonly duration: string;
+  readonly tokens?: string;
+  readonly status: "success" | "error";
+  readonly error?: string;
+}
+
+interface ValidationLogEntry {
+  readonly id: string;
+  readonly timestamp: string;
+  readonly type: ValidatorKey;
+  readonly attempts: number;
+  readonly invalidJson?: string;
+  readonly errors?: string[];
+}
+
+export interface ValidationLogPayload {
+  type: ValidatorKey;
+  attempts: number;
+  invalidJson?: string;
+  errors?: string[];
+}
+
+interface DeveloperConsoleData {
+  gptLogs: readonly GPTInteractionLogEntry[];
+  validationLogs: readonly ValidationLogEntry[];
+  settings: {
+    dumpInvalidJson: boolean;
+    dumpAjvErrors: boolean;
+  };
+}
+
+const LOG_LIMIT = 50;
+
+const formatDuration = (durationMs: number): string => {
+  if (!Number.isFinite(durationMs)) {
+    return "-";
+  }
+  if (durationMs >= 1000) {
+    return `${(durationMs / 1000).toFixed(2)} s`;
+  }
+  return `${durationMs.toFixed(0)} ms`;
+};
+
+const formatTokens = (usage?: GPTUsageMetrics): string | undefined => {
+  if (!usage) return undefined;
+  const parts: string[] = [];
+  if (typeof usage.inputTokens === "number") {
+    parts.push(`in ${usage.inputTokens}`);
+  }
+  if (typeof usage.outputTokens === "number") {
+    parts.push(`out ${usage.outputTokens}`);
+  }
+  if (typeof usage.totalTokens === "number") {
+    parts.push(`total ${usage.totalTokens}`);
+  }
+  return parts.length ? parts.join(" · ") : undefined;
+};
+
+const createId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+};
+
+export class DeveloperConsole extends Application {
+  #gptLogs: GPTInteractionLogEntry[] = [];
+  #validationLogs: ValidationLogEntry[] = [];
+
+  static override get defaultOptions(): ApplicationOptions {
+    return {
+      ...super.defaultOptions,
+      id: "handy-dandy-developer-console",
+      title: "Handy Dandy – Developer Console",
+      template: `modules/${CONSTANTS.MODULE_ID}/templates/developer-console.hbs`,
+      width: 600,
+      height: 520,
+      resizable: true,
+      classes: ["handy-dandy", "developer-console"],
+    } satisfies ApplicationOptions;
+  }
+
+  recordGPTInteraction(payload: GPTInteractionLogPayload): void {
+    const entry: GPTInteractionLogEntry = {
+      id: createId(),
+      timestamp: new Date(payload.startedAt).toLocaleTimeString(),
+      promptHash: payload.promptHash,
+      schemaName: payload.schemaName,
+      model: payload.model,
+      method: payload.method,
+      duration: formatDuration(payload.durationMs),
+      tokens: formatTokens(payload.usage),
+      status: payload.success ? "success" : "error",
+      error: payload.error,
+    };
+
+    this.#gptLogs.push(entry);
+    if (this.#gptLogs.length > LOG_LIMIT) {
+      this.#gptLogs = this.#gptLogs.slice(-LOG_LIMIT);
+    }
+    this.render(false);
+  }
+
+  recordValidationFailure(details: ValidationLogPayload): void {
+    const entry: ValidationLogEntry = {
+      id: createId(),
+      timestamp: new Date(Date.now()).toLocaleTimeString(),
+      type: details.type,
+      attempts: details.attempts,
+      invalidJson: details.invalidJson,
+      errors: details.errors,
+    };
+
+    this.#validationLogs.push(entry);
+    if (this.#validationLogs.length > LOG_LIMIT) {
+      this.#validationLogs = this.#validationLogs.slice(-LOG_LIMIT);
+    }
+    this.render(false);
+  }
+
+  clear(): void {
+    this.#gptLogs = [];
+    this.#validationLogs = [];
+    this.render(false);
+  }
+
+  shouldDumpInvalidJson(): boolean {
+    const settings = game.settings;
+    return Boolean(settings?.get(CONSTANTS.MODULE_ID, "developerDumpInvalidJson"));
+  }
+
+  shouldDumpAjvErrors(): boolean {
+    const settings = game.settings;
+    return Boolean(settings?.get(CONSTANTS.MODULE_ID, "developerDumpAjvErrors"));
+  }
+
+  override getData(): DeveloperConsoleData {
+    return {
+      gptLogs: [...this.#gptLogs].reverse(),
+      validationLogs: [...this.#validationLogs].reverse(),
+      settings: {
+        dumpInvalidJson: this.shouldDumpInvalidJson(),
+        dumpAjvErrors: this.shouldDumpAjvErrors(),
+      },
+    } satisfies DeveloperConsoleData;
+  }
+
+  override activateListeners(html: JQuery): void {
+    super.activateListeners(html);
+
+    html.find<HTMLButtonElement>("button[data-action='clear-logs']").on("click", () => {
+      this.clear();
+    });
+
+    html.find<HTMLInputElement>("input[name='dumpInvalidJson']").on("change", async (event) => {
+      const input = event.currentTarget as HTMLInputElement;
+      await game.settings?.set(CONSTANTS.MODULE_ID, "developerDumpInvalidJson", input.checked);
+      this.render(false);
+    });
+
+    html.find<HTMLInputElement>("input[name='dumpAjvErrors']").on("change", async (event) => {
+      const input = event.currentTarget as HTMLInputElement;
+      await game.settings?.set(CONSTANTS.MODULE_ID, "developerDumpAjvErrors", input.checked);
+      this.render(false);
+    });
+  }
+}

--- a/src/scripts/dev/state.ts
+++ b/src/scripts/dev/state.ts
@@ -1,0 +1,11 @@
+import type { DeveloperConsole } from "./developer-console";
+
+let consoleInstance: DeveloperConsole | null = null;
+
+export function setDeveloperConsole(instance: DeveloperConsole): void {
+  consoleInstance = instance;
+}
+
+export function getDeveloperConsole(): DeveloperConsole | null {
+  return consoleInstance;
+}

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -6,6 +6,8 @@ import { insertSidebarButtons } from "./setup/sidebarButtons";
 import { SchemaTool } from "./tools/schema-tool";
 import { DataEntryTool } from "./tools/data-entry-tool";
 import { GPTClient } from "./gpt/client";
+import { DeveloperConsole } from "./dev/developer-console";
+import { setDeveloperConsole } from "./dev/state";
 import {
   DEFAULT_GENERATION_SEED,
   generateAction,
@@ -74,6 +76,9 @@ declare global {
         schemaTool: SchemaTool,
         dataEntryTool: DataEntryTool,
       },
+      developer: {
+        console: DeveloperConsole,
+      },
       flows: {
         exportSelection: typeof exportSelectedEntities;
         generateBatch: typeof generateAndImportBatch;
@@ -91,7 +96,8 @@ Hooks.once("init", async () => {
   await loadTemplates({
     "schema-tool": `${CONSTANTS.TEMPLATE_PATH}/schema-tool.hbs`,
     "schema-node": `${CONSTANTS.TEMPLATE_PATH}/schema-node.hbs`,
-    "data-entry-tool": `${CONSTANTS.TEMPLATE_PATH}/data-entry-tool.hbs`
+    "data-entry-tool": `${CONSTANTS.TEMPLATE_PATH}/data-entry-tool.hbs`,
+    "developer-console": `${CONSTANTS.TEMPLATE_PATH}/developer-console.hbs`
   });
 });
 
@@ -111,11 +117,16 @@ Hooks.once("setup", () => {
       schemaTool: new SchemaTool,
       dataEntryTool: new DataEntryTool,
     },
+    developer: {
+      console: new DeveloperConsole(),
+    },
     flows: {
       exportSelection: exportSelectedEntities,
       generateBatch: generateAndImportBatch,
     },
   };
+
+  setDeveloperConsole(game.handyDandy!.developer.console);
 });
 
 // ---------- READY -----------------------------------------------------------

--- a/src/scripts/setup/settings.ts
+++ b/src/scripts/setup/settings.ts
@@ -57,4 +57,22 @@ export function registerSettings(): void {
     type: Number,
     default: null
   });
+
+  settings.register(CONSTANTS.MODULE_ID, "developerDumpInvalidJson", {
+    name: "Developer: Dump Invalid JSON",
+    hint: "When enabled, failed Ensure Valid attempts will record the last invalid JSON in the developer console.",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
+  settings.register(CONSTANTS.MODULE_ID, "developerDumpAjvErrors", {
+    name: "Developer: Dump Ajv Errors",
+    hint: "When enabled, failed Ensure Valid attempts will record Ajv error messages in the developer console.",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+  });
 }

--- a/src/scripts/setup/sidebarButtons.ts
+++ b/src/scripts/setup/sidebarButtons.ts
@@ -56,6 +56,19 @@ export function insertSidebarButtons(controls: SceneControl[]): void {
         onClick: () => {
           void runBatchGenerationFlow();
         }
+      },
+      {
+        name: "developer-console",
+        title: "Developer Console",
+        icon: "fas fa-terminal",
+        button: true,
+        onClick: () => {
+          if (!game.handyDandy) {
+            ui.notifications?.error("Handy Dandy module is not initialized.");
+            return;
+          }
+          game.handyDandy.developer.console.render(true);
+        }
       }
     ]
   };

--- a/src/scripts/ui/ensure-valid-toast.ts
+++ b/src/scripts/ui/ensure-valid-toast.ts
@@ -1,0 +1,74 @@
+import { CONSTANTS } from "../constants";
+import type { EntityType, SchemaDataFor } from "../schemas";
+import type { EnsureValidError } from "../validation/ensure-valid";
+import type { ImporterOptions } from "../flows/batch";
+
+interface EnsureValidRetryToastOptions<T extends EntityType> {
+  type: T;
+  name: string;
+  error: EnsureValidError<T>;
+  importer: (json: SchemaDataFor<T>, options: ImporterOptions) => Promise<unknown>;
+  importerOptions: ImporterOptions;
+  registerHandler?: (handler: () => Promise<void>) => void;
+}
+
+const createId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+};
+
+export function createEnsureValidRetryHandler<T extends EntityType>(
+  options: EnsureValidRetryToastOptions<T>,
+): () => Promise<void> {
+  const { error, importer, importerOptions, name, type } = options;
+
+  return async () => {
+    try {
+      const repaired = await error.repair();
+      await importer(repaired, importerOptions);
+      ui.notifications?.info(`${CONSTANTS.MODULE_NAME} | Repaired ${type} "${name}" successfully.`);
+    } catch (repairError) {
+      const message = repairError instanceof Error ? repairError.message : String(repairError);
+      ui.notifications?.error(`${CONSTANTS.MODULE_NAME} | Repair attempt failed: ${message}`);
+      console.error(`${CONSTANTS.MODULE_NAME} | Repair attempt failed`, repairError);
+      throw repairError;
+    }
+  };
+}
+
+export function showEnsureValidRetryToast<T extends EntityType>(
+  options: EnsureValidRetryToastOptions<T>,
+): void {
+  const id = createId();
+  const message = `${CONSTANTS.MODULE_NAME} | Failed to import ${options.type} "${options.name}". `;
+  const html = `${message}<button type="button" class="handy-dandy-retry" data-retry-id="${id}">Retry with repair</button>`;
+
+  ui.notifications?.error(html, { permanent: true });
+
+  const handler = createEnsureValidRetryHandler(options);
+
+  if (typeof options.registerHandler === "function") {
+    options.registerHandler(handler);
+    return;
+  }
+
+  setTimeout(() => {
+    const container = ui.notifications?.element?.[0];
+    if (!container) return;
+    const button = container.querySelector<HTMLButtonElement>(`button.handy-dandy-retry[data-retry-id="${id}"]`);
+    if (!button) return;
+
+    button.addEventListener("click", async () => {
+      if (button.disabled) return;
+      button.disabled = true;
+      try {
+        await handler();
+        button.closest<HTMLElement>(".notification")?.remove();
+      } catch (_error) {
+        button.disabled = false;
+      }
+    });
+  }, 0);
+}

--- a/src/styles/developer-console.css
+++ b/src/styles/developer-console.css
@@ -1,0 +1,87 @@
+.developer-console__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: 100%;
+}
+
+.developer-console__settings {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.developer-console__settings label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0;
+}
+
+.developer-console__settings button {
+  margin-left: auto;
+}
+
+.developer-console__section {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 0.5rem;
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+.developer-console__section h3 {
+  margin-top: 0;
+}
+
+.developer-console__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.developer-console__table th,
+.developer-console__table td {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.25rem 0.5rem;
+  vertical-align: top;
+}
+
+.developer-console__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.developer-console__validation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.developer-console__validation-entry {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.developer-console__validation-entry header {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.developer-console__validation-entry details {
+  margin-top: 0.5rem;
+}
+
+.developer-console__validation-entry pre {
+  max-height: 200px;
+  overflow: auto;
+}
+
+.developer-console__empty {
+  font-style: italic;
+  opacity: 0.75;
+}

--- a/src/templates/developer-console.hbs
+++ b/src/templates/developer-console.hbs
@@ -1,0 +1,85 @@
+<form class="developer-console__form">
+  <section class="developer-console__settings">
+    <label>
+      <input type="checkbox" name="dumpInvalidJson" {{#if settings.dumpInvalidJson}}checked{{/if}}>
+      Dump last invalid JSON
+    </label>
+    <label>
+      <input type="checkbox" name="dumpAjvErrors" {{#if settings.dumpAjvErrors}}checked{{/if}}>
+      Dump Ajv errors
+    </label>
+    <button type="button" data-action="clear-logs">
+      <i class="fas fa-trash"></i>
+      Clear Logs
+    </button>
+  </section>
+
+  <section class="developer-console__section">
+    <h3>GPT Interactions</h3>
+    {{#if gptLogs.length}}
+      <table class="developer-console__table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Schema</th>
+            <th>Method</th>
+            <th>Duration</th>
+            <th>Tokens</th>
+            <th>Status</th>
+            <th>Error</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each gptLogs}}
+            <tr>
+              <td>{{timestamp}}</td>
+              <td>{{schemaName}}<br><small>{{promptHash}}</small></td>
+              <td>{{method}}</td>
+              <td>{{duration}}</td>
+              <td>{{#if tokens}}{{tokens}}{{else}}—{{/if}}</td>
+              <td>{{status}}</td>
+              <td>{{#if error}}<code>{{error}}</code>{{else}}—{{/if}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    {{else}}
+      <p class="developer-console__empty">No GPT interactions recorded.</p>
+    {{/if}}
+  </section>
+
+  <section class="developer-console__section">
+    <h3>Validation Failures</h3>
+    {{#if validationLogs.length}}
+      <div class="developer-console__validation-list">
+        {{#each validationLogs}}
+          <article class="developer-console__validation-entry">
+            <header>
+              <strong>{{type}}</strong>
+              <span>{{timestamp}}</span>
+              <span>{{attempts}} attempt{{#unless (eq attempts 1)}}s{{/unless}}</span>
+            </header>
+            {{#if invalidJson}}
+              <details>
+                <summary>Invalid JSON</summary>
+                <pre>{{invalidJson}}</pre>
+              </details>
+            {{/if}}
+            {{#if errors}}
+              <details>
+                <summary>Ajv Errors</summary>
+                <ul>
+                  {{#each errors}}
+                    <li>{{this}}</li>
+                  {{/each}}
+                </ul>
+              </details>
+            {{/if}}
+          </article>
+        {{/each}}
+      </div>
+    {{else}}
+      <p class="developer-console__empty">No validation diagnostics recorded.</p>
+    {{/if}}
+  </section>
+</form>

--- a/tests/retry-toast.test.ts
+++ b/tests/retry-toast.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createEnsureValidRetryHandler } from "../src/scripts/ui/ensure-valid-toast";
+import { EnsureValidError } from "../src/scripts/validation/ensure-valid";
+
+(globalThis as any).ui = {
+  notifications: {
+    info: () => undefined,
+    error: () => undefined,
+  },
+};
+
+test("createEnsureValidRetryHandler invokes repair and importer", async () => {
+  let repairCalls = 0;
+  const error = new EnsureValidError<"item">(
+    "Failed",
+    [],
+    {},
+    {},
+    {
+      type: "item",
+      repair: async () => {
+        repairCalls += 1;
+        return {
+          schema_version: 1,
+          systemId: "pf2e",
+          type: "item",
+          slug: "retry",
+          name: "Retry",
+          itemType: "wand",
+          rarity: "common",
+        } as any;
+      },
+    },
+  );
+
+  let importerCalled = false;
+  const handler = createEnsureValidRetryHandler({
+    type: "item",
+    name: "Retry",
+    error,
+    importer: async (json) => {
+      importerCalled = true;
+      assert.equal(json.name, "Retry");
+      return {};
+    },
+    importerOptions: {},
+  });
+
+  await handler();
+
+  assert.equal(repairCalls, 1);
+  assert.equal(importerCalled, true);
+});


### PR DESCRIPTION
## Summary
- wrap GPT client interactions with structured logging and record them in the developer console for inspection
- add developer settings and UI to review validation dumps and expose the console from the scene controls
- enhance ensureValid failure notifications with a repair retry handler and cover the flow with automated tests

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68e9d61d9148832f94a018032067d608