### PR TITLE
Expose developer helpers on game.handyDandy.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ These settings are used to initialise the OpenAI SDK when the game is ready.
 3. The OpenAI client is available to other macros as `game.handyDandy.openai` if
    configured.
 
+## Developer Helpers
+
+GMs and users with developer mode enabled gain access to a dedicated
+`game.handyDandy.dev` namespace with helper methods for local testing:
+
+- `generateAction(input, options?)` – runs the full generation pipeline using
+  the active GPT client and logs the prompt input and resulting payload to the
+  browser console.
+- `validate(type, payload, options?)` – validates or repairs a payload via the
+  standard Ensure Valid flow. The helper logs the payload and validation
+  summary, and honours options such as `maxAttempts` or `useGPT` when you need
+  to disable automatic repairs.
+- `importAction(json, options?)` – performs the same sanity checks and import
+  routine used by the UI, reporting results in the console.
+
+All helpers write structured output to the developer console using collapsed
+console groups. Access is restricted to the GM or when a developer module/flag
+is active; otherwise the helpers emit a warning and throw an error.
+
 ## Compatibility
 
 The module targets Foundry **V12** and is tested with the **pf2e** system.  The

--- a/src/scripts/dev/tools.ts
+++ b/src/scripts/dev/tools.ts
@@ -1,0 +1,293 @@
+import { CONSTANTS } from "../constants";
+import type { ActionPromptInput } from "../prompts";
+import type { ActionSchemaData, SchemaDataFor, ValidatorKey } from "../schemas";
+import type { ImportOptions } from "../mappers/import";
+import type { GPTClient } from "../gpt/client";
+import type {
+  EnsureValidOptions,
+  EnsureValidPromptContext,
+} from "../validation/ensure-valid";
+
+type GenerateActionFn = (
+  input: ActionPromptInput,
+  options?: DevGenerateActionOptions,
+) => Promise<ActionSchemaData>;
+
+type EnsureValidFn = <K extends ValidatorKey>(
+  options: EnsureValidOptions<K>,
+) => Promise<SchemaDataFor<K>>;
+
+type ImportActionFn = (
+  json: ActionSchemaData,
+  options?: ImportOptions,
+) => Promise<Item>;
+
+type DevConsole = Pick<Console, "groupCollapsed" | "groupEnd" | "info" | "warn" | "error">;
+
+export interface DevGenerateActionOptions {
+  seed?: number;
+  maxAttempts?: number;
+  gptClient?: Pick<GPTClient, "generateWithSchema">;
+}
+
+export interface DevValidateOptions<K extends ValidatorKey> {
+  maxAttempts?: number;
+  useGPT?: boolean;
+  gptClient?: Pick<GPTClient, "generateWithSchema">;
+  promptBuilder?: (context: EnsureValidPromptContext<K>) => string;
+  schema?: EnsureValidOptions<K>["schema"];
+}
+
+export interface DevNamespace {
+  generateAction: (
+    input: ActionPromptInput,
+    options?: DevGenerateActionOptions,
+  ) => Promise<ActionSchemaData>;
+  validate: <K extends ValidatorKey>(
+    type: K,
+    payload: unknown,
+    options?: DevValidateOptions<K>,
+  ) => Promise<SchemaDataFor<K>>;
+  importAction: (
+    json: ActionSchemaData,
+    options?: ImportOptions,
+  ) => Promise<Item>;
+}
+
+interface DevNamespaceDependencies {
+  canAccess: () => boolean;
+  getGptClient: () => Pick<GPTClient, "generateWithSchema"> | null;
+  generateAction: GenerateActionFn;
+  ensureValid: EnsureValidFn;
+  importAction: ImportActionFn;
+  console: DevConsole;
+}
+
+interface DeveloperApiCandidate {
+  active?: boolean;
+  enabled?: boolean;
+  isEnabled?: boolean;
+  toolsActive?: boolean;
+  tools?: { active?: boolean };
+}
+
+interface DeveloperModuleCandidate {
+  active?: boolean;
+  api?: { isDeveloper?: () => boolean };
+}
+
+const MODULE_PREFIX = `${CONSTANTS.MODULE_NAME} |` as const;
+
+const toBoolean = (value: unknown): boolean | null =>
+  typeof value === "boolean" ? value : null;
+
+const safeGetBooleanSetting = (
+  settings: Game["settings"] | undefined,
+  namespace: string,
+  key: string,
+): boolean | null => {
+  if (!settings || typeof settings.get !== "function") {
+    return null;
+  }
+
+  try {
+    const value = settings.get(namespace, key);
+    return toBoolean(value);
+  } catch (error) {
+    if (CONFIG?.debug?.hooks) {
+      console.warn(
+        MODULE_PREFIX,
+        `Failed to read setting ${namespace}.${key}:`,
+        error,
+      );
+    }
+    return null;
+  }
+};
+
+const readDeveloperApiFlag = (developer: unknown): boolean => {
+  if (!developer || typeof developer !== "object") {
+    return false;
+  }
+
+  const candidate = developer as DeveloperApiCandidate;
+  const values: (boolean | null | undefined)[] = [
+    toBoolean(candidate.active),
+    toBoolean(candidate.enabled),
+    toBoolean(candidate.isEnabled),
+    toBoolean(candidate.toolsActive),
+    toBoolean(candidate.tools?.active),
+  ];
+
+  return values.some((flag) => flag === true);
+};
+
+const readDeveloperModuleFlag = (modules: Game["modules"] | undefined): boolean => {
+  if (!modules || typeof modules.get !== "function") {
+    return false;
+  }
+
+  const identifiers = ["developer-mode", "foundryvtt-devmode", "foundryvtt-developer-tools"];
+  return identifiers.some((id) => {
+    const entry = modules.get(id) as DeveloperModuleCandidate | undefined;
+    if (!entry) {
+      return false;
+    }
+    if (toBoolean(entry.active)) {
+      return true;
+    }
+    const api = entry.api;
+    return Boolean(api && typeof api.isDeveloper === "function" && api.isDeveloper());
+  });
+};
+
+const logOperation = async <T>(
+  console: DevConsole,
+  operation: string,
+  details: Record<string, unknown>,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  console.groupCollapsed(`${MODULE_PREFIX} ${operation}`);
+  try {
+    for (const [label, value] of Object.entries(details)) {
+      if (typeof value === "undefined") continue;
+      console.info(`${label}:`, value);
+    }
+
+    const result = await fn();
+    console.info("Result:", result);
+    return result;
+  } catch (error) {
+    console.error("Error:", error);
+    throw error;
+  } finally {
+    console.groupEnd();
+  }
+};
+
+const assertDeveloperAccess = (deps: DevNamespaceDependencies, operation: string): void => {
+  if (deps.canAccess()) {
+    return;
+  }
+
+  const message = `${MODULE_PREFIX} Developer helper \"${operation}\" is restricted to GMs or developer mode.`;
+  deps.console.warn(message);
+  throw new Error(message);
+};
+
+const summarizeValidateOptions = <K extends ValidatorKey>(
+  options: DevValidateOptions<K> | undefined,
+) => {
+  if (!options) return undefined;
+
+  const summary: Record<string, unknown> = {};
+  if (typeof options.maxAttempts === "number") {
+    summary.maxAttempts = options.maxAttempts;
+  }
+  if (typeof options.useGPT === "boolean") {
+    summary.useGPT = options.useGPT;
+  }
+  if (options.promptBuilder) {
+    summary.promptBuilder = "[function]";
+  }
+  if (options.schema) {
+    summary.schema = "[custom schema]";
+  }
+  if (options.gptClient) {
+    summary.gptClient = "[custom client]";
+  }
+
+  return summary;
+};
+
+export function canUseDeveloperTools(): boolean {
+  const gameInstance = (globalThis as { game?: Game }).game;
+  if (!gameInstance) {
+    return false;
+  }
+
+  if (gameInstance.user?.isGM) {
+    return true;
+  }
+
+  if (readDeveloperApiFlag((gameInstance as unknown as { developer?: unknown }).developer)) {
+    return true;
+  }
+
+  const developerSetting =
+    safeGetBooleanSetting(gameInstance.settings, "core", "developerMode") ??
+    safeGetBooleanSetting(gameInstance.settings, "core", "devMode");
+  if (developerSetting) {
+    return true;
+  }
+
+  if (readDeveloperModuleFlag(gameInstance.modules)) {
+    return true;
+  }
+
+  return false;
+}
+
+export function createDevNamespace(deps: DevNamespaceDependencies): DevNamespace {
+  return {
+    generateAction: async (input, options) => {
+      assertDeveloperAccess(deps, "generateAction");
+      const { gptClient: _gptClient, ...optionSnapshot } = options ?? {};
+      return logOperation(
+        deps.console,
+        "dev.generateAction",
+        {
+          input,
+          options: Object.keys(optionSnapshot).length ? optionSnapshot : undefined,
+        },
+        () => deps.generateAction(input, options),
+      );
+    },
+
+    validate: async (type, payload, options) => {
+      assertDeveloperAccess(deps, "validate");
+      const {
+        maxAttempts,
+        useGPT = true,
+        gptClient: explicitClient,
+        promptBuilder,
+        schema,
+      } = options ?? {};
+
+      const gptClient = explicitClient ?? (useGPT ? deps.getGptClient() ?? undefined : undefined);
+
+      return logOperation(
+        deps.console,
+        `dev.validate(${type})`,
+        {
+          payload,
+          options: summarizeValidateOptions(options),
+        },
+        () =>
+          deps.ensureValid({
+            type,
+            payload,
+            maxAttempts,
+            gptClient,
+            promptBuilder,
+            schema,
+          }),
+      );
+    },
+
+    importAction: async (json, options) => {
+      assertDeveloperAccess(deps, "importAction");
+      const snapshot = options ? { ...options } : undefined;
+      return logOperation(
+        deps.console,
+        "dev.importAction",
+        {
+          json,
+          options: snapshot,
+        },
+        () => deps.importAction(json, options),
+      );
+    },
+  } satisfies DevNamespace;
+}
+

--- a/src/scripts/mappers/import.ts
+++ b/src/scripts/mappers/import.ts
@@ -30,7 +30,7 @@ interface PackIndexEntry {
   system?: { slug?: string | null };
 }
 
-type ImportOptions = {
+export type ImportOptions = {
   packId?: string;
   folderId?: string;
 };

--- a/tests/dev-tools.test.ts
+++ b/tests/dev-tools.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  canUseDeveloperTools,
+  createDevNamespace,
+  type DevGenerateActionOptions,
+} from "../src/scripts/dev/tools";
+import type { ActionPromptInput } from "../src/scripts/prompts";
+import type { ActionSchemaData } from "../src/scripts/schemas";
+import type {
+  EnsureValidOptions,
+  SchemaDataFor,
+  ValidatorKey,
+} from "../src/scripts/validation/ensure-valid";
+import type { ImportOptions } from "../src/scripts/mappers/import";
+import type { GPTClient } from "../src/scripts/gpt/client";
+
+const noopGenerateAction = async (): Promise<ActionSchemaData> =>
+  ({ name: "noop", systemId: "pf2e" } as ActionSchemaData);
+
+const noopEnsureValid = async <K extends ValidatorKey>(
+  options: EnsureValidOptions<K>,
+): Promise<SchemaDataFor<K>> =>
+  ({ ...(options.payload as Record<string, unknown>) } as SchemaDataFor<K>);
+
+const noopImportAction = async (
+  _json: ActionSchemaData,
+  _options?: ImportOptions,
+): Promise<Item> => ({ uuid: "Item.noop" } as Item);
+
+function createConsoleStub() {
+  const groups: unknown[][] = [];
+  const infos: unknown[][] = [];
+  const warns: unknown[][] = [];
+  const errors: unknown[][] = [];
+  let endCount = 0;
+
+  const stub = {
+    groupCollapsed: (...args: unknown[]) => {
+      groups.push(args);
+    },
+    groupEnd: () => {
+      endCount += 1;
+    },
+    info: (...args: unknown[]) => {
+      infos.push(args);
+    },
+    warn: (...args: unknown[]) => {
+      warns.push(args);
+    },
+    error: (...args: unknown[]) => {
+      errors.push(args);
+    },
+  } satisfies Pick<Console, "groupCollapsed" | "groupEnd" | "info" | "warn" | "error">;
+
+  return { stub, groups, infos, warns, errors, getEndCount: () => endCount };
+}
+
+test("dev.generateAction delegates to the provided generator and logs output", async () => {
+  const prompt: ActionPromptInput = {
+    systemId: "pf2e",
+    title: "Test Action",
+    referenceText: "Performs a quick strike.",
+  };
+  const options: DevGenerateActionOptions = { seed: 42 };
+  const expected: ActionSchemaData = {
+    name: "Test Action",
+    systemId: "pf2e",
+  } as ActionSchemaData;
+
+  const consoleRecorder = createConsoleStub();
+  let capturedOptions: DevGenerateActionOptions | undefined;
+
+  const namespace = createDevNamespace({
+    canAccess: () => true,
+    getGptClient: () => null,
+    generateAction: async (input, opts) => {
+      assert.equal(input, prompt);
+      capturedOptions = opts;
+      return expected;
+    },
+    ensureValid: noopEnsureValid,
+    importAction: noopImportAction,
+    console: consoleRecorder.stub,
+  });
+
+  const result = await namespace.generateAction(prompt, options);
+
+  assert.equal(result, expected);
+  assert.deepEqual(capturedOptions, options);
+  assert.equal(consoleRecorder.groups.length, 1);
+  assert.ok(String(consoleRecorder.groups[0][0]).includes("dev.generateAction"));
+  assert.ok(consoleRecorder.infos.some((entry) => entry[0] === "Result:"));
+  assert.equal(consoleRecorder.getEndCount(), 1);
+});
+
+test("developer helpers enforce access restrictions", async () => {
+  const consoleRecorder = createConsoleStub();
+  const namespace = createDevNamespace({
+    canAccess: () => false,
+    getGptClient: () => null,
+    generateAction: noopGenerateAction,
+    ensureValid: noopEnsureValid,
+    importAction: noopImportAction,
+    console: consoleRecorder.stub,
+  });
+
+  await assert.rejects(
+    namespace.generateAction({
+      systemId: "pf2e",
+      title: "Forbidden",
+      referenceText: "",
+    }),
+    /restricted to GMs or developer mode/,
+  );
+
+  assert.equal(consoleRecorder.warns.length, 1);
+});
+
+test("dev.validate injects the active GPT client by default", async () => {
+  const consoleRecorder = createConsoleStub();
+  const gptClient = { generateWithSchema: async () => ({}) } as unknown as Pick<
+    GPTClient,
+    "generateWithSchema"
+  >;
+
+  let capturedOptions: EnsureValidOptions<"action"> | undefined;
+
+  const namespace = createDevNamespace({
+    canAccess: () => true,
+    getGptClient: () => gptClient,
+    generateAction: noopGenerateAction,
+    ensureValid: async (options) => {
+      capturedOptions = options as EnsureValidOptions<"action">;
+      return options.payload as SchemaDataFor<"action">;
+    },
+    importAction: noopImportAction,
+    console: consoleRecorder.stub,
+  });
+
+  const payload = { name: "Validated" };
+  await namespace.validate("action", payload);
+
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions?.gptClient, gptClient);
+});
+
+test("dev.validate respects the useGPT override", async () => {
+  const consoleRecorder = createConsoleStub();
+  const gptClient = { generateWithSchema: async () => ({}) } as unknown as Pick<
+    GPTClient,
+    "generateWithSchema"
+  >;
+
+  let capturedOptions: EnsureValidOptions<"action"> | undefined;
+
+  const namespace = createDevNamespace({
+    canAccess: () => true,
+    getGptClient: () => gptClient,
+    generateAction: noopGenerateAction,
+    ensureValid: async (options) => {
+      capturedOptions = options as EnsureValidOptions<"action">;
+      return options.payload as SchemaDataFor<"action">;
+    },
+    importAction: noopImportAction,
+    console: consoleRecorder.stub,
+  });
+
+  const payload = { name: "Manual" };
+  await namespace.validate("action", payload, { useGPT: false });
+
+  assert.ok(capturedOptions);
+  assert.equal(capturedOptions?.gptClient, undefined);
+});
+
+test("canUseDeveloperTools returns true for GM users", () => {
+  const previousGame = (globalThis as { game?: Game }).game;
+  (globalThis as { game?: Game }).game = {
+    user: { isGM: true } as unknown as Game["user"],
+    settings: {
+      get: () => false,
+    } as unknown as Game["settings"],
+    modules: new Map(),
+  } as unknown as Game;
+
+  try {
+    assert.equal(canUseDeveloperTools(), true);
+  } finally {
+    if (previousGame) {
+      (globalThis as { game?: Game }).game = previousGame;
+    } else {
+      delete (globalThis as { game?: Game }).game;
+    }
+  }
+});
+
+test("canUseDeveloperTools detects active developer modules", () => {
+  const previousGame = (globalThis as { game?: Game }).game;
+  (globalThis as { game?: Game }).game = {
+    user: { isGM: false } as unknown as Game["user"],
+    settings: {
+      get: () => false,
+    } as unknown as Game["settings"],
+    modules: {
+      get: (id: string) => (id === "developer-mode" ? { active: true } : undefined),
+    } as unknown as Game["modules"],
+  } as unknown as Game;
+
+  try {
+    assert.equal(canUseDeveloperTools(), true);
+  } finally {
+    if (previousGame) {
+      (globalThis as { game?: Game }).game = previousGame;
+    } else {
+      delete (globalThis as { game?: Game }).game;
+    }
+  }
+});
+
+test("canUseDeveloperTools returns false when no access is granted", () => {
+  const previousGame = (globalThis as { game?: Game }).game;
+  (globalThis as { game?: Game }).game = {
+    user: { isGM: false } as unknown as Game["user"],
+    settings: {
+      get: () => false,
+    } as unknown as Game["settings"],
+    modules: {
+      get: () => undefined,
+    } as unknown as Game["modules"],
+  } as unknown as Game;
+
+  try {
+    assert.equal(canUseDeveloperTools(), false);
+  } finally {
+    if (previousGame) {
+      (globalThis as { game?: Game }).game = previousGame;
+    } else {
+      delete (globalThis as { game?: Game }).game;
+    }
+  }
+});
+


### PR DESCRIPTION
## Summary
- add a developer-only `game.handyDandy.dev` namespace that wraps the generation, validation, and import pipelines with console logging
- gate the helpers behind GM/developer checks, export the import options type, and wire the namespace during setup
- document the helpers in the README and add smoke tests covering access control and GPT client usage

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68e9db94d3b0832f930858f34a1f30f1