### PR TITLE
Fix schema typing and GPT client for OpenAI v5

### DIFF
--- a/src/scripts/dev/tools.ts
+++ b/src/scripts/dev/tools.ts
@@ -81,10 +81,13 @@ const MODULE_PREFIX = `${CONSTANTS.MODULE_NAME} |` as const;
 const toBoolean = (value: unknown): boolean | null =>
   typeof value === "boolean" ? value : null;
 
-const safeGetBooleanSetting = (
+const safeGetBooleanSetting = <
+  N extends ClientSettings.Namespace,
+  K extends ClientSettings.KeyFor<N>,
+>(
   settings: Game["settings"] | undefined,
-  namespace: string,
-  key: string,
+  namespace: N,
+  key: K,
 ): boolean | null => {
   if (!settings || typeof settings.get !== "function") {
     return null;
@@ -215,8 +218,8 @@ export function canUseDeveloperTools(): boolean {
   }
 
   const developerSetting =
-    safeGetBooleanSetting(gameInstance.settings, "core", "developerMode") ??
-    safeGetBooleanSetting(gameInstance.settings, "core", "devMode");
+    safeGetBooleanSetting(gameInstance.settings, "core" as any, "developerMode" as any) ??
+    safeGetBooleanSetting(gameInstance.settings, "core" as any, "devMode" as any);
   if (developerSetting) {
     return true;
   }

--- a/src/scripts/flows/batch-ui.ts
+++ b/src/scripts/flows/batch-ui.ts
@@ -96,14 +96,18 @@ async function promptBatchGeneration(): Promise<GenerationBatchOptions<EntityTyp
     </form>
   `;
 
-  const response = await Dialog.prompt<{
-    entityType: string;
-    payload: string;
-    packId: string;
-    folderId: string;
-    seed: string;
-    maxAttempts: string;
-  } | null>({
+  const response = await Dialog.prompt<
+    {
+      entityType: string;
+      payload: string;
+      packId: string;
+      folderId: string;
+      seed: string;
+      maxAttempts: string;
+    } | null,
+    undefined,
+    { jQuery: true }
+  >({
     title: `${CONSTANTS.MODULE_NAME} | Batch Generate`,
     content,
     label: "Run Batch",

--- a/src/scripts/mappers/export.ts
+++ b/src/scripts/mappers/export.ts
@@ -529,10 +529,11 @@ export function fromFoundryActor(doc: FoundryActor): ActorSchemaData {
   const rarityValue = doc.system?.traits?.rarity;
 
   const languagesSources: unknown[] = [];
+  const languagesSource = doc.system?.traits?.languages;
   const traitLanguages =
-    doc.system?.traits?.languages && "value" in (doc.system?.traits?.languages ?? {})
-      ? (doc.system?.traits?.languages as { value?: unknown }).value
-      : doc.system?.traits?.languages;
+    typeof languagesSource === "object" && languagesSource !== null && "value" in languagesSource
+      ? (languagesSource as { value?: unknown }).value
+      : languagesSource;
   if (traitLanguages !== undefined) {
     languagesSources.push(traitLanguages);
   }

--- a/src/scripts/schemas/index.ts
+++ b/src/scripts/schemas/index.ts
@@ -53,33 +53,33 @@ type BaseEntity<TType extends EntityType> = {
 
 export interface ActionSchemaData extends BaseEntity<"action"> {
   actionType: ActionExecution;
-  traits?: string[];
-  requirements?: string;
+  traits?: string[] | null;
+  requirements?: string | null;
   description: string;
-  img?: string;
-  rarity?: Rarity;
-  source?: string;
+  img?: string | null;
+  rarity?: Rarity | null;
+  source?: string | null;
 }
 
 export interface ItemSchemaData extends BaseEntity<"item"> {
   itemType: ItemCategory;
   rarity: Rarity;
   level: number;
-  price?: number;
-  traits?: string[];
-  description?: string;
-  img?: string;
-  source?: string;
+  price?: number | null;
+  traits?: string[] | null;
+  description?: string | null;
+  img?: string | null;
+  source?: string | null;
 }
 
 export interface ActorSchemaData extends BaseEntity<"actor"> {
   actorType: ActorCategory;
   rarity: Rarity;
   level: number;
-  traits?: string[];
-  languages?: string[];
-  img?: string;
-  source?: string;
+  traits?: string[] | null;
+  languages?: string[] | null;
+  img?: string | null;
+  source?: string | null;
 }
 
 export interface PackEntrySchemaData {
@@ -89,8 +89,8 @@ export interface PackEntrySchemaData {
   entityType: EntityType;
   name: string;
   slug: string;
-  img?: string;
-  sort?: number;
+  img?: string | null;
+  sort?: number | null;
   folder?: string | null;
 }
 
@@ -117,13 +117,14 @@ export const actionSchema = {
     traits: {
       type: "array",
       items: { type: "string", minLength: 1 },
+      nullable: true,
       default: [] as const
     },
-    requirements: { type: "string", default: "" },
+    requirements: { type: "string", nullable: true, default: "" },
     description: { type: "string", minLength: 1 },
-    img: { type: "string", format: "uri-reference", default: "" },
-    rarity: { type: "string", enum: RARITIES, default: "common" as const },
-    source: { type: "string", default: "" }
+    img: { type: "string", format: "uri-reference", nullable: true, default: "" },
+    rarity: { type: "string", enum: RARITIES, nullable: true, default: "common" as const },
+    source: { type: "string", nullable: true, default: "" }
   }
 } satisfies JSONSchemaType<ActionSchemaData>;
 
@@ -138,15 +139,16 @@ export const itemSchema = {
     itemType: { type: "string", enum: ITEM_CATEGORIES },
     rarity: { type: "string", enum: RARITIES },
     level: { type: "integer", minimum: 0 },
-    price: { type: "number", minimum: 0, default: 0 },
+    price: { type: "number", minimum: 0, nullable: true, default: 0 },
     traits: {
       type: "array",
       items: { type: "string", minLength: 1 },
+      nullable: true,
       default: [] as const
     },
-    description: { type: "string", default: "" },
-    img: { type: "string", format: "uri-reference", default: "" },
-    source: { type: "string", default: "" }
+    description: { type: "string", nullable: true, default: "" },
+    img: { type: "string", format: "uri-reference", nullable: true, default: "" },
+    source: { type: "string", nullable: true, default: "" }
   }
 } satisfies JSONSchemaType<ItemSchemaData>;
 
@@ -164,15 +166,17 @@ export const actorSchema = {
     traits: {
       type: "array",
       items: { type: "string", minLength: 1 },
+      nullable: true,
       default: [] as const
     },
     languages: {
       type: "array",
       items: { type: "string", minLength: 1 },
+      nullable: true,
       default: [] as const
     },
-    img: { type: "string", format: "uri-reference", default: "" },
-    source: { type: "string", default: "" }
+    img: { type: "string", format: "uri-reference", nullable: true, default: "" },
+    source: { type: "string", nullable: true, default: "" }
   }
 } satisfies JSONSchemaType<ActorSchemaData>;
 
@@ -188,8 +192,8 @@ export const packEntrySchema = {
     entityType: { type: "string", enum: ENTITY_TYPES },
     name: baseMeta.name,
     slug: baseMeta.slug,
-    img: { type: "string", format: "uri-reference", default: "" },
-    sort: { type: "integer", default: 0 },
+    img: { type: "string", format: "uri-reference", nullable: true, default: "" },
+    sort: { type: "integer", nullable: true, default: 0 },
     folder: { type: "string", nullable: true, default: null }
   }
 } satisfies JSONSchemaType<PackEntrySchemaData>;
@@ -230,5 +234,19 @@ export const validators: {
 export type ValidatorMap = typeof validators;
 export type ValidatorKey = keyof ValidatorMap;
 export type EntityValidator = ValidatorMap[keyof ValidatorMap];
+
+export type CanonicalEntityMap = {
+  action: ActionSchemaData;
+  item: ItemSchemaData;
+  actor: ActorSchemaData;
+};
+
+export type SchemaDataFor<K extends ValidatorKey> = K extends "action"
+  ? ActionSchemaData
+  : K extends "item"
+    ? ItemSchemaData
+    : K extends "actor"
+      ? ActorSchemaData
+      : PackEntrySchemaData;
 
 export { ajv as ajvInstance };

--- a/src/scripts/validation/ensure-valid.ts
+++ b/src/scripts/validation/ensure-valid.ts
@@ -12,6 +12,7 @@ import {
   type ActorSchemaData,
   type ItemSchemaData,
   type PackEntrySchemaData,
+  type SchemaDataFor,
   type SchemaMap,
   type ValidatorKey,
 } from "../schemas";
@@ -20,13 +21,7 @@ import type { JsonSchemaDefinition, GPTClient } from "../gpt/client";
 import { getDeveloperConsole } from "../dev/state";
 import type { ValidationLogPayload } from "../dev/developer-console";
 
-export type SchemaDataFor<K extends ValidatorKey> = K extends "action"
-  ? ActionSchemaData
-  : K extends "item"
-    ? ItemSchemaData
-    : K extends "actor"
-      ? ActorSchemaData
-      : PackEntrySchemaData;
+export type { SchemaDataFor, ValidatorKey } from "../schemas";
 
 export interface EnsureValidDiagnostics<K extends ValidatorKey> {
   attempt: number;

--- a/src/types/handy-dandy-settings.d.ts
+++ b/src/types/handy-dandy-settings.d.ts
@@ -12,6 +12,8 @@ declare module "fvtt-types/configuration" {
     "handy-dandy.GPTTemperature": number;
     "handy-dandy.GPTTopP": number;
     "handy-dandy.GPTSeed": number | null;
+    "handy-dandy.developerDumpInvalidJson": boolean;
+    "handy-dandy.developerDumpAjvErrors": boolean;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
     "moduleResolution": "bundler",
     "types": ["fvtt-types"],
     "strict": true
-  }
+  },
+  "include": ["src/scripts/**/*", "src/types/**/*"]
 }


### PR DESCRIPTION
## Summary
- allow nullable schema fields, export shared validator types, and document additional module settings
- update the GPT client to hash prompts without node:crypto, attach metadata, and request structured JSON via the v5 responses API
- tighten developer and batch tooling generics while making the import/export helpers null-safe for optional schema fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9e0953dfc832f9eee966442e8c924