### PR TITLE
Add in-app tool guide to highlight Handy Dandy controls

### DIFF
--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -9,6 +9,7 @@ import { GPTClient } from "./gpt/client";
 import { DeveloperConsole } from "./dev/developer-console";
 import { setDeveloperConsole } from "./dev/state";
 import { createDevNamespace, canUseDeveloperTools, type DevNamespace } from "./dev/tools";
+import { ToolOverview } from "./ui/tool-overview";
 import {
   DEFAULT_GENERATION_SEED,
   generateAction,
@@ -78,6 +79,7 @@ declare global {
       applications: {
         schemaTool: SchemaTool,
         dataEntryTool: DataEntryTool,
+        toolOverview: ToolOverview,
       },
       developer: {
         console: DeveloperConsole,
@@ -101,7 +103,8 @@ Hooks.once("init", async () => {
     "schema-tool": `${CONSTANTS.TEMPLATE_PATH}/schema-tool.hbs`,
     "schema-node": `${CONSTANTS.TEMPLATE_PATH}/schema-node.hbs`,
     "data-entry-tool": `${CONSTANTS.TEMPLATE_PATH}/data-entry-tool.hbs`,
-    "developer-console": `${CONSTANTS.TEMPLATE_PATH}/developer-console.hbs`
+    "developer-console": `${CONSTANTS.TEMPLATE_PATH}/developer-console.hbs`,
+    "tool-overview": `${CONSTANTS.TEMPLATE_PATH}/tool-overview.hbs`,
   });
 });
 
@@ -133,6 +136,7 @@ Hooks.once("setup", () => {
     applications: {
       schemaTool: new SchemaTool,
       dataEntryTool: new DataEntryTool,
+      toolOverview: new ToolOverview(),
     },
     developer: {
       console: developerConsole,
@@ -151,6 +155,11 @@ Hooks.once("setup", () => {
 Hooks.once("ready", () => {
   // Only the GM needs an API key to call OpenAI from the browser
   if (!game.user?.isGM) return;
+
+  ui.notifications?.info(
+    `${CONSTANTS.MODULE_NAME} tools live under the Scene Controls toolbar. ` +
+      `Open Handy Dandy Tools or the Tool Guide from Module Settings for quick access.`,
+  );
 
   const key = game.settings.get(CONSTANTS.MODULE_ID, "GPTApiKey") as string;
   if (!key) {

--- a/src/scripts/setup/settings.ts
+++ b/src/scripts/setup/settings.ts
@@ -1,5 +1,6 @@
 // scripts/settings.ts
 import { CONSTANTS } from "../constants";
+import { ToolOverview } from "../ui/tool-overview";
 
 export function registerSettings(): void {
   const settings = game.settings!;
@@ -56,6 +57,15 @@ export function registerSettings(): void {
     config: true,
     type: Number,
     default: null
+  });
+
+  settings.registerMenu(CONSTANTS.MODULE_ID, "toolGuide", {
+    name: "Handy Dandy Tool Guide",
+    label: "Open Tool Guide",
+    hint: "Open a quick reference that shows where to access each Handy Dandy tool inside Foundry.",
+    icon: "fas fa-compass",
+    type: ToolOverview,
+    restricted: false,
   });
 
   settings.register(CONSTANTS.MODULE_ID, "developerDumpInvalidJson", {

--- a/src/scripts/setup/sidebarButtons.ts
+++ b/src/scripts/setup/sidebarButtons.ts
@@ -12,6 +12,19 @@ export function insertSidebarButtons(controls: SceneControl[]): void {
     activeTool: "schema-tool", // Mandatory in v12 :contentReference[oaicite:0]{index=0}
     tools: <SceneControlTool[]>[
       {
+        name: "tool-guide",
+        title: "Tool Guide",
+        icon: "fas fa-compass",
+        button: true,
+        onClick: () => {
+          if (!game.handyDandy) {
+            ui.notifications?.error("Handy Dandy module is not initialized.");
+            return;
+          }
+          game.handyDandy.applications.toolOverview.render(true);
+        }
+      },
+      {
         name: "schema-tool",
         title: "Schema Tool",
         icon: "fas fa-magic",

--- a/src/scripts/ui/tool-overview.ts
+++ b/src/scripts/ui/tool-overview.ts
@@ -1,0 +1,160 @@
+import { CONSTANTS } from "../constants";
+import { runBatchGenerationFlow, runExportSelectionFlow } from "../flows/batch-ui";
+
+interface ToolCardData {
+  id: string;
+  title: string;
+  icon: string;
+  description: string;
+  location: string;
+  buttonAction?: string;
+  buttonLabel?: string;
+  buttonIcon?: string;
+}
+
+interface ToolOverviewData {
+  tools: ToolCardData[];
+}
+
+export class ToolOverview extends FormApplication {
+  constructor(options?: Partial<FormApplicationOptions>) {
+    super(undefined, options);
+  }
+
+  static override get defaultOptions(): FormApplicationOptions {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      id: "handy-dandy-tool-overview",
+      title: "Handy Dandy Tool Guide",
+      template: `${CONSTANTS.TEMPLATE_PATH}/tool-overview.hbs`,
+      width: 600,
+      height: "auto",
+      classes: ["handy-dandy", "tool-overview"],
+      submitOnChange: false,
+      closeOnSubmit: true,
+    });
+  }
+
+  override async getData(): Promise<ToolOverviewData> {
+    return {
+      tools: [
+        {
+          id: "schema-tool",
+          title: "Schema Tool",
+          icon: "fas fa-magic",
+          description: "Inspect the data model of any Foundry document and copy schema paths to the clipboard.",
+          location: "Scene Controls → Handy Dandy Tools → Schema Tool",
+          buttonAction: "open-schema",
+          buttonLabel: "Open Schema Tool",
+          buttonIcon: "fas fa-arrow-up-right-from-square",
+        },
+        {
+          id: "data-entry-tool",
+          title: "Data Entry Tool",
+          icon: "fas fa-edit",
+          description: "Reformat Pathfinder 2e / Starfinder 2e rules text into Foundry-ready rich text.",
+          location: "Scene Controls → Handy Dandy Tools → Data Entry Tool",
+          buttonAction: "open-data-entry",
+          buttonLabel: "Open Data Entry Tool",
+          buttonIcon: "fas fa-arrow-up-right-from-square",
+        },
+        {
+          id: "export-selection",
+          title: "Export Selection",
+          icon: "fas fa-file-export",
+          description: "Export the currently selected actors, items, or journals to JSON for sharing or backups.",
+          location: "Scene Controls → Handy Dandy Tools → Export Selection",
+          buttonAction: "export-selection",
+          buttonLabel: "Start Export",
+          buttonIcon: "fas fa-file-export",
+        },
+        {
+          id: "batch-generate",
+          title: "Batch Generate & Import",
+          icon: "fas fa-diagram-project",
+          description: "Generate a batch of actions or items with GPT and automatically import the validated results.",
+          location: "Scene Controls → Handy Dandy Tools → Batch Generate & Import",
+          buttonAction: "batch-generate",
+          buttonLabel: "Launch Batch Flow",
+          buttonIcon: "fas fa-diagram-project",
+        },
+        {
+          id: "developer-console",
+          title: "Developer Console",
+          icon: "fas fa-terminal",
+          description: "Access developer helpers for validation, imports, and GPT-driven workflows (GM or developer mode only).",
+          location: "Scene Controls → Handy Dandy Tools → Developer Console",
+          buttonAction: "open-dev-console",
+          buttonLabel: "Open Developer Console",
+          buttonIcon: "fas fa-terminal",
+        },
+      ],
+    } satisfies ToolOverviewData;
+  }
+
+  override activateListeners(html: JQuery): void {
+    super.activateListeners(html);
+
+    const buttons = html.find<HTMLButtonElement>("button[data-action]");
+    buttons.on("click", event => {
+      const action = (event.currentTarget as HTMLButtonElement).dataset["action"];
+      switch (action) {
+        case "open-schema":
+          this.#openSchemaTool();
+          break;
+        case "open-data-entry":
+          this.#openDataEntryTool();
+          break;
+        case "export-selection":
+          this.#runExportSelection();
+          break;
+        case "batch-generate":
+          this.#runBatchGeneration();
+          break;
+        case "open-dev-console":
+          this.#openDeveloperConsole();
+          break;
+        default:
+          console.warn(`${CONSTANTS.MODULE_NAME} | Unknown tool overview action: ${action}`);
+      }
+    });
+  }
+
+  protected override async _updateObject(
+    _event: Event,
+    _formData: Record<string, unknown>,
+  ): Promise<void> {
+    // No form submission behaviour; the dialog is informational only.
+  }
+
+  #openSchemaTool(): void {
+    if (!game.handyDandy?.applications.schemaTool) {
+      ui.notifications?.error("Handy Dandy module is not initialized.");
+      return;
+    }
+    game.handyDandy.applications.schemaTool.render(true);
+  }
+
+  #openDataEntryTool(): void {
+    if (!game.handyDandy?.applications.dataEntryTool) {
+      ui.notifications?.error("Handy Dandy module is not initialized.");
+      return;
+    }
+    game.handyDandy.applications.dataEntryTool.render(true);
+  }
+
+  #runExportSelection(): void {
+    void runExportSelectionFlow();
+  }
+
+  #runBatchGeneration(): void {
+    void runBatchGenerationFlow();
+  }
+
+  #openDeveloperConsole(): void {
+    if (!game.handyDandy?.developer.console) {
+      ui.notifications?.error("Handy Dandy module is not initialized.");
+      return;
+    }
+    game.handyDandy.developer.console.render(true);
+  }
+}

--- a/src/templates/tool-overview.hbs
+++ b/src/templates/tool-overview.hbs
@@ -1,0 +1,36 @@
+<section class="handy-tool-guide flexcol">
+  <p class="scene-controls-hint">
+    <i class="fas fa-info-circle"></i>
+    <span>
+      Handy Dandy adds its tools to the <strong>Scene Controls</strong> toolbar on the left side of the canvas.
+      Look for the <i class="fas fa-screwdriver-wrench"></i> icon labelled <strong>Handy Dandy Tools</strong>.
+    </span>
+  </p>
+
+  <ol class="access-steps">
+    <li>Open any scene as a GM.</li>
+    <li>Hover over the left toolbar and click <strong>Handy Dandy Tools</strong>.</li>
+    <li>Choose the tool button you need from the palette.</li>
+  </ol>
+
+  <hr>
+
+  <div class="tool-grid">
+    {{#each tools}}
+      <article class="tool-card">
+        <header class="tool-card__header">
+          <h3><i class="{{icon}}" aria-hidden="true"></i> {{title}}</h3>
+        </header>
+        <p class="tool-card__location"><strong>Location:</strong> {{location}}</p>
+        <p class="tool-card__description">{{description}}</p>
+        {{#if buttonAction}}
+          <footer class="tool-card__actions">
+            <button type="button" data-action="{{buttonAction}}">
+              <i class="{{buttonIcon}}" aria-hidden="true"></i> {{buttonLabel}}
+            </button>
+          </footer>
+        {{/if}}
+      </article>
+    {{/each}}
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a Tool Guide application that explains where the Handy Dandy controls live and links to each tool
- expose the guide from the scene controls palette and module settings while notifying GMs on ready
- load the new template at startup so the overview renders inside Foundry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9e61e4d00832fa968d25cc951e911