### PR TITLE
Fix Foundry v13 sidebar tool initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handy-dandy",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "type": "module",
   "scripts": {
     "build": "webpack --mode production",


### PR DESCRIPTION
## Summary
- detect Foundry v13+ and register toolbar tools using object maps instead of arrays
- bump the module version to 1.5.7

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea7208c378832f9bf5e585fba3c987