### PR TITLE
Make release workflow manually triggered

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,12 @@ permissions:
   contents: write
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        description: Optional notes for the release
+        required: false
+        default: ''
 
 jobs:
   build-and-release:
@@ -47,6 +50,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: './dist/module.json,./module.zip'
           tag: latest
+          body: ${{ github.event.inputs.release_notes }}
       
       - name: Create Version Release
         id: create_version_release
@@ -59,3 +63,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: './dist/module.json,./module.zip'
           tag: ${{ steps.get_version.outputs.version }}
+          body: ${{ github.event.inputs.release_notes }}


### PR DESCRIPTION
## Summary
- switch the release pipeline to run only when manually dispatched
- allow optional release notes input that is passed to both release artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea7e975238832f8403d86f2ccaab0c