### PR TITLE
Add GPT-5 models to dropdown selection

### DIFF
--- a/src/scripts/gpt/client.ts
+++ b/src/scripts/gpt/client.ts
@@ -2,6 +2,7 @@ import type { OpenAI } from "openai";
 import { CONSTANTS } from "../constants";
 import { getDeveloperConsole } from "../dev/state";
 import type { GPTUsageMetrics } from "../dev/developer-console";
+import { DEFAULT_GPT_MODEL, isValidGPTModel } from "./models";
 
 export interface JsonSchemaDefinition {
   name: string;
@@ -85,7 +86,7 @@ export const readGPTSettings = (): GPTClientConfig => {
   const seedSetting = settings?.get(CONSTANTS.MODULE_ID, "GPTSeed");
 
   const config: GPTClientConfig = {
-    model: model ?? "gpt-4.1-mini",
+    model: isValidGPTModel(model) ? model : DEFAULT_GPT_MODEL,
     temperature: sanitizeNumber(temperature) ?? 0,
     top_p: sanitizeNumber(top_p) ?? 1,
   };

--- a/src/scripts/gpt/models.ts
+++ b/src/scripts/gpt/models.ts
@@ -1,0 +1,21 @@
+export const GPT_MODEL_CHOICES = {
+  "gpt-5.1-mini": "GPT-5.1 Mini",
+  "gpt-5.1": "GPT-5.1",
+  "gpt-5-preview": "GPT-5 Preview",
+  "gpt-4.1-mini": "GPT-4.1 Mini",
+  "gpt-4.1": "GPT-4.1",
+  "gpt-4.1-nano": "GPT-4.1 Nano",
+  "gpt-4o-mini": "GPT-4o Mini",
+  "gpt-4o": "GPT-4o",
+} as const satisfies Record<string, string>;
+
+export type GPTModelId = keyof typeof GPT_MODEL_CHOICES;
+
+export const DEFAULT_GPT_MODEL: GPTModelId = "gpt-4.1-mini";
+
+export function isValidGPTModel(model: unknown): model is GPTModelId {
+  return (
+    typeof model === "string" &&
+    Object.prototype.hasOwnProperty.call(GPT_MODEL_CHOICES, model)
+  );
+}

--- a/src/scripts/setup/settings.ts
+++ b/src/scripts/setup/settings.ts
@@ -1,6 +1,7 @@
 // scripts/settings.ts
 import { CONSTANTS } from "../constants";
 import { ToolOverview } from "../ui/tool-overview";
+import { DEFAULT_GPT_MODEL, GPT_MODEL_CHOICES } from "../gpt/models";
 
 export function registerSettings(): void {
   const settings = game.settings!;
@@ -29,7 +30,8 @@ export function registerSettings(): void {
     scope: "client",
     config: true,
     type: String,
-    default: "gpt-4.1-mini"
+    choices: GPT_MODEL_CHOICES,
+    default: DEFAULT_GPT_MODEL,
   });
 
   settings.register(CONSTANTS.MODULE_ID, "GPTTemperature", {

--- a/src/types/handy-dandy-settings.d.ts
+++ b/src/types/handy-dandy-settings.d.ts
@@ -2,13 +2,14 @@
 export {};
 
 declare module "fvtt-types/configuration" {
+  type HandyDandyGPTModel = import("../scripts/gpt/models").GPTModelId;
   interface SettingConfig {
     /**
      * Settings owned by the Handy-Dandy module
      */
     "handy-dandy.GPTApiKey": string;
     "handy-dandy.GPTOrganization": string;
-    "handy-dandy.GPTModel": string;
+    "handy-dandy.GPTModel": HandyDandyGPTModel;
     "handy-dandy.GPTTemperature": number;
     "handy-dandy.GPTTopP": number;
     "handy-dandy.GPTSeed": number | null;

--- a/tests/gpt-client.test.ts
+++ b/tests/gpt-client.test.ts
@@ -47,7 +47,7 @@ beforeEach(() => {
       get(moduleId: string, key: string) {
         if (moduleId !== "handy-dandy") throw new Error("Unknown module");
         const values: Record<string, unknown> = {
-          GPTModel: "test-model",
+          GPTModel: "gpt-4o",
           GPTTemperature: 0.5,
           GPTTopP: 0.75,
           GPTSeed: 123,
@@ -61,7 +61,7 @@ beforeEach(() => {
 test("readGPTSettings pulls module settings with sane defaults", () => {
   const config = readGPTSettings();
   assert.deepEqual(config, {
-    model: "test-model",
+    model: "gpt-4o",
     temperature: 0.5,
     top_p: 0.75,
     seed: 123,


### PR DESCRIPTION
## Summary
- add a shared list of supported GPT models and expose it via a dropdown setting
- validate the stored GPT model and fall back to the default when necessary
- tighten the GPT model setting types and update the client tests
- extend the shared model list with GPT-5 options for the dropdown

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68eae837a4cc832f84c8cb6ae27e5c31