### PR TITLE
Fix tool guide activation and refresh GPT client on setting changes

### DIFF
--- a/src/scripts/setup/settings.ts
+++ b/src/scripts/setup/settings.ts
@@ -2,6 +2,7 @@
 import { CONSTANTS } from "../constants";
 import { ToolOverview } from "../ui/tool-overview";
 import { DEFAULT_GPT_MODEL, GPT_MODEL_CHOICES } from "../gpt/models";
+import { updateGPTClientFromSettings } from "../gpt/client";
 
 export function registerSettings(): void {
   const settings = game.settings!;
@@ -32,6 +33,9 @@ export function registerSettings(): void {
     type: String,
     choices: GPT_MODEL_CHOICES,
     default: DEFAULT_GPT_MODEL,
+    onChange: () => {
+      updateGPTClientFromSettings();
+    },
   });
 
   settings.register(CONSTANTS.MODULE_ID, "GPTTemperature", {
@@ -40,7 +44,10 @@ export function registerSettings(): void {
     scope: "client",
     config: true,
     type: Number,
-    default: 0.2
+    default: 0.2,
+    onChange: () => {
+      updateGPTClientFromSettings();
+    },
   });
 
   settings.register(CONSTANTS.MODULE_ID, "GPTTopP", {
@@ -49,7 +56,10 @@ export function registerSettings(): void {
     scope: "client",
     config: true,
     type: Number,
-    default: 1
+    default: 1,
+    onChange: () => {
+      updateGPTClientFromSettings();
+    },
   });
 
   settings.register(CONSTANTS.MODULE_ID, "GPTSeed", {
@@ -58,7 +68,10 @@ export function registerSettings(): void {
     scope: "client",
     config: true,
     type: Number,
-    default: null
+    default: null,
+    onChange: () => {
+      updateGPTClientFromSettings();
+    },
   });
 
   settings.registerMenu(CONSTANTS.MODULE_ID, "toolGuide", {

--- a/src/scripts/setup/sidebarButtons.ts
+++ b/src/scripts/setup/sidebarButtons.ts
@@ -75,7 +75,7 @@ export function insertSidebarButtons(controls: ControlCollection): void {
     icon: "fa-solid fa-screwdriver-wrench",
     layer: "interface",
     visible: true,
-    activeTool: "tool-guide",
+    activeTool: "",
     onChange: noop,
     onToolChange: noop,
     tools,
@@ -86,7 +86,6 @@ export function insertSidebarButtons(controls: ControlCollection): void {
     title: "Tool Guide",
     icon: "fa-solid fa-compass",
     toggle: true,
-    active: true,
     onClick: toggled => {
       const handyDandy = requireNamespace();
       const toolOverview = handyDandy.applications.toolOverview;


### PR DESCRIPTION
## Summary
- prevent the Handy Dandy tool guide from opening automatically when the control group is selected
- avoid sending unsupported temperature values to GPT-5 models and centralize sampling parameter handling
- refresh the GPT client whenever GPT model or sampling settings change so new choices apply immediately

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68eaf36a1e8c832f815409d95c67cbb3