### PR TITLE
Add PF2e trait browser tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ written in TypeScript and built with Webpack.
   Foundry-ready rich text.  Options exist to add condition links, action icons
   and other tweaks.  The module is a straight port of the original Python script
   used by the maintainer.
+- **Trait Browser Tool** – explore Pathfinder 2e trait dictionaries straight
+  from the system configuration. Choose a trait category, view localized
+  details, and click to copy slugs for use in macros or data entry.
 - **OpenAI integration** – the module stores an OpenAI client on
   `game.handyDandy.openai` once you enter your API key.  Other modules or macros
   can make use of this client.

--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -5,6 +5,7 @@ import { OpenAI } from "openai";
 import { insertSidebarButtons, type ControlCollection } from "./setup/sidebarButtons";
 import { SchemaTool } from "./tools/schema-tool";
 import { DataEntryTool } from "./tools/data-entry-tool";
+import { TraitBrowserTool } from "./tools/trait-browser-tool";
 import { GPTClient } from "./gpt/client";
 import { DeveloperConsole } from "./dev/developer-console";
 import { setDeveloperConsole } from "./dev/state";
@@ -83,6 +84,7 @@ declare global {
       applications: {
         schemaTool: SchemaTool,
         dataEntryTool: DataEntryTool,
+        traitBrowserTool: TraitBrowserTool,
         toolOverview: ToolOverview,
       },
       developer: {
@@ -107,6 +109,7 @@ Hooks.once("init", async () => {
     "schema-tool": `${CONSTANTS.TEMPLATE_PATH}/schema-tool.hbs`,
     "schema-node": `${CONSTANTS.TEMPLATE_PATH}/schema-node.hbs`,
     "data-entry-tool": `${CONSTANTS.TEMPLATE_PATH}/data-entry-tool.hbs`,
+    "trait-browser-tool": `${CONSTANTS.TEMPLATE_PATH}/trait-browser-tool.hbs`,
     "developer-console": `${CONSTANTS.TEMPLATE_PATH}/developer-console.hbs`,
     "tool-overview": `${CONSTANTS.TEMPLATE_PATH}/tool-overview.hbs`,
   });
@@ -140,6 +143,7 @@ Hooks.once("setup", () => {
     applications: {
       schemaTool: new SchemaTool,
       dataEntryTool: new DataEntryTool,
+      traitBrowserTool: new TraitBrowserTool,
       toolOverview: new ToolOverview(),
     },
     developer: {

--- a/src/scripts/setup/sidebarButtons.ts
+++ b/src/scripts/setup/sidebarButtons.ts
@@ -131,6 +131,18 @@ export function insertSidebarButtons(controls: ControlCollection): void {
   });
 
   compatibilityAddTool(handyGroup.tools, {
+    name: "trait-browser",
+    title: "Trait Browser",
+    icon: "fa-solid fa-tags",
+    button: true,
+    onClick: () => {
+      console.debug(`${CONSTANTS.MODULE_NAME} | Opening Trait Browser Tool`);
+      requireNamespace().applications.traitBrowserTool.render(true);
+    },
+    onChange: noop,
+  });
+
+  compatibilityAddTool(handyGroup.tools, {
     name: "export-selection",
     title: "Export Selection",
     icon: "fa-solid fa-file-export",

--- a/src/scripts/tools/trait-browser-tool.ts
+++ b/src/scripts/tools/trait-browser-tool.ts
@@ -1,0 +1,206 @@
+import { CONSTANTS } from "../constants";
+
+interface TraitCategoryOption {
+  key: string;
+  label: string;
+  count: number;
+}
+
+interface TraitDisplayEntry {
+  slug: string;
+  label: string;
+  description?: string;
+}
+
+interface TraitBrowserData {
+  categories: TraitCategoryOption[];
+  selectedKey: string | null;
+  traits: TraitDisplayEntry[];
+  error?: string;
+}
+
+type Pf2eTraitDictionary = Record<string, string>;
+
+type TraitCategory = TraitCategoryOption & {
+  traits: TraitDisplayEntry[];
+};
+
+export class TraitBrowserTool extends Application {
+  #selectedKey: string | null = null;
+
+  static override get defaultOptions(): ApplicationOptions {
+    return foundry.utils.mergeObject(super.defaultOptions, {
+      id: "handy-dandy-trait-browser",
+      title: "PF2e Trait Browser",
+      template: `${CONSTANTS.TEMPLATE_PATH}/trait-browser-tool.hbs`,
+      width: 500,
+      height: 600,
+      resizable: true,
+      classes: ["handy-dandy", "trait-browser-tool"],
+    });
+  }
+
+  override getData(): TraitBrowserData {
+    const categories = collectTraitCategories();
+    if (categories.length === 0) {
+      return {
+        categories: [],
+        selectedKey: null,
+        traits: [],
+        error: "PF2e trait data is unavailable. Ensure the Pathfinder 2e system is active.",
+      } satisfies TraitBrowserData;
+    }
+
+    const selectedKey = this.#ensureSelectedKey(categories);
+    const selectedCategory = categories.find(category => category.key === selectedKey);
+
+    return {
+      categories: categories.map(({ key, label, count }) => ({ key, label, count })),
+      selectedKey,
+      traits: selectedCategory?.traits ?? [],
+    } satisfies TraitBrowserData;
+  }
+
+  override activateListeners(html: JQuery): void {
+    super.activateListeners(html);
+
+    html.find<HTMLSelectElement>("select[name='trait-category']").on("change", event => {
+      this.#selectedKey = (event.currentTarget as HTMLSelectElement).value;
+      this.render(false);
+    });
+
+    html.find<HTMLElement>("[data-action='copy-trait']").on("click", async event => {
+      const element = event.currentTarget as HTMLElement;
+      const slug = element.dataset["slug"];
+      if (!slug) return;
+
+      try {
+        await navigator.clipboard.writeText(slug);
+        ui.notifications?.info(`Copied trait slug ${slug}`);
+      } catch (error) {
+        console.warn(`${CONSTANTS.MODULE_NAME} | Failed to copy trait slug`, error);
+        ui.notifications?.warn("Unable to copy trait slug to the clipboard.");
+      }
+    });
+  }
+
+  #ensureSelectedKey(categories: TraitCategory[]): string {
+    if (this.#selectedKey && categories.some(category => category.key === this.#selectedKey)) {
+      return this.#selectedKey;
+    }
+
+    const [first] = categories;
+    this.#selectedKey = first.key;
+    return first.key;
+  }
+}
+
+function collectTraitCategories(): TraitCategory[] {
+  const pf2eConfig = (CONFIG as { PF2E?: Record<string, unknown> }).PF2E;
+  if (!pf2eConfig) return [];
+
+  const traitDescriptions = extractTraitDescriptions(pf2eConfig);
+
+  return Object.entries(pf2eConfig)
+    .filter(([key, value]) => isTraitDictionaryKey(key) && isTraitDictionary(value))
+    .map(([key, value]) => buildTraitCategory(key, value as Pf2eTraitDictionary, traitDescriptions))
+    .filter((category): category is TraitCategory => category.traits.length > 0)
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function isTraitDictionaryKey(key: string): boolean {
+  return /(Traits|Tags)$/i.test(key) && key !== "traitDescriptions";
+}
+
+function isTraitDictionary(value: unknown): value is Pf2eTraitDictionary {
+  if (!value || typeof value !== "object") return false;
+  return Object.values(value as Record<string, unknown>).every(entry => typeof entry === "string");
+}
+
+function buildTraitCategory(
+  key: string,
+  traits: Pf2eTraitDictionary,
+  descriptions: Pf2eTraitDictionary,
+): TraitCategory {
+  const entries: TraitDisplayEntry[] = Object.entries(traits)
+    .map(([slug, labelKey]) => ({
+      slug,
+      label: localizeLabel(labelKey, slug),
+      description: localizeDescription(descriptions[slug]),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  return {
+    key,
+    label: formatCategoryLabel(key),
+    count: entries.length,
+    traits: entries,
+  } satisfies TraitCategory;
+}
+
+function extractTraitDescriptions(config: Record<string, unknown>): Pf2eTraitDictionary {
+  const rawDescriptions = config["traitDescriptions"];
+  if (!rawDescriptions || typeof rawDescriptions !== "object") return {};
+
+  return Object.fromEntries(
+    Object.entries(rawDescriptions as Record<string, unknown>)
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+function localizeLabel(labelKey: string, fallbackSlug: string): string {
+  if (typeof labelKey === "string" && game.i18n) {
+    const localized = game.i18n.localize(labelKey);
+    if (localized && localized !== labelKey) {
+      return localized;
+    }
+  }
+
+  return formatSlug(fallbackSlug);
+}
+
+function localizeDescription(descriptionKey: string | undefined): string | undefined {
+  if (!descriptionKey) return undefined;
+  if (!game.i18n) return descriptionKey;
+
+  const localized = game.i18n.localize(descriptionKey);
+  return localized && localized !== descriptionKey ? localized : descriptionKey;
+}
+
+function formatCategoryLabel(key: string): string {
+  const suffix = key.endsWith("Tags") ? " Tags" : " Traits";
+  const withoutSuffix = key.replace(/(Traits|Tags)$/i, "");
+  const spaced = withoutSuffix
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[\-_]/g, " ")
+    .trim();
+
+  if (!spaced) {
+    return suffix.trim();
+  }
+
+  return `${toTitleCase(spaced)}${suffix}`;
+}
+
+function formatSlug(slug: string): string {
+  const spaced = slug.replace(/[-_]/g, " ");
+  return toTitleCase(spaced);
+}
+
+function toTitleCase(value: string): string {
+  const acronyms = new Set(["pf2e", "npc", "pc", "gm", "dc"]);
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(segment => {
+      const lower = segment.toLowerCase();
+      if (acronyms.has(lower)) {
+        return lower.toUpperCase();
+      }
+      if (segment.length <= 3 && segment === segment.toUpperCase()) {
+        return segment;
+      }
+      return segment.charAt(0).toUpperCase() + segment.slice(1);
+    })
+    .join(" ");
+}

--- a/src/scripts/ui/tool-overview.ts
+++ b/src/scripts/ui/tool-overview.ts
@@ -58,6 +58,16 @@ export class ToolOverview extends FormApplication {
           buttonIcon: "fas fa-arrow-up-right-from-square",
         },
         {
+          id: "trait-browser",
+          title: "Trait Browser",
+          icon: "fas fa-tags",
+          description: "Browse PF2e trait dictionaries directly from the system and copy trait slugs with a click.",
+          location: "Scene Controls → Handy Dandy Tools → Trait Browser",
+          buttonAction: "open-trait-browser",
+          buttonLabel: "Open Trait Browser",
+          buttonIcon: "fas fa-arrow-up-right-from-square",
+        },
+        {
           id: "export-selection",
           title: "Export Selection",
           icon: "fas fa-file-export",
@@ -105,6 +115,9 @@ export class ToolOverview extends FormApplication {
         case "open-data-entry":
           this.#openDataEntryTool();
           break;
+        case "open-trait-browser":
+          this.#openTraitBrowserTool();
+          break;
         case "export-selection":
           this.#runExportSelection();
           break;
@@ -141,6 +154,14 @@ export class ToolOverview extends FormApplication {
       return;
     }
     game.handyDandy.applications.dataEntryTool.render(true);
+  }
+
+  #openTraitBrowserTool(): void {
+    if (!game.handyDandy?.applications.traitBrowserTool) {
+      ui.notifications?.error("Handy Dandy module is not initialized.");
+      return;
+    }
+    game.handyDandy.applications.traitBrowserTool.render(true);
   }
 
   #runExportSelection(): void {

--- a/src/styles/trait-browser-tool.css
+++ b/src/styles/trait-browser-tool.css
@@ -1,0 +1,69 @@
+.trait-browser {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.trait-browser__error {
+  color: #b71c1c;
+  font-weight: bold;
+}
+
+.trait-browser__list {
+  flex: 1;
+  overflow: auto;
+}
+
+.trait-browser__list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.trait-browser__item {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.trait-browser__item:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.trait-browser__item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.trait-browser__label {
+  font-weight: 600;
+}
+
+.trait-browser__slug {
+  font-family: var(--font-mono, "Courier New", Courier, monospace);
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.trait-browser__description {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: #444;
+}
+
+.trait-browser__empty,
+.trait-browser__hint {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.trait-browser__hint {
+  text-align: right;
+}

--- a/src/templates/trait-browser-tool.hbs
+++ b/src/templates/trait-browser-tool.hbs
@@ -1,0 +1,38 @@
+<form class="trait-browser">
+  {{#if error}}
+    <p class="trait-browser__error">{{error}}</p>
+  {{else}}
+    <div class="form-group">
+      <label for="trait-category-select">Trait Category</label>
+      <select name="trait-category" id="trait-category-select">
+        {{#each categories}}
+          <option value="{{this.key}}" {{#if (eq this.key ../selectedKey)}}selected{{/if}}>
+            {{this.label}} ({{this.count}})
+          </option>
+        {{/each}}
+      </select>
+    </div>
+
+    <section class="trait-browser__list">
+      {{#if traits.length}}
+        <ul>
+          {{#each traits}}
+            <li class="trait-browser__item" data-action="copy-trait" data-slug="{{this.slug}}">
+              <div class="trait-browser__item-header">
+                <span class="trait-browser__label">{{this.label}}</span>
+                <code class="trait-browser__slug">{{this.slug}}</code>
+              </div>
+              {{#if this.description}}
+                <p class="trait-browser__description">{{this.description}}</p>
+              {{/if}}
+            </li>
+          {{/each}}
+        </ul>
+      {{else}}
+        <p class="trait-browser__empty">No traits available for this category.</p>
+      {{/if}}
+    </section>
+
+    <p class="trait-browser__hint">Click a trait to copy its slug.</p>
+  {{/if}}
+</form>


### PR DESCRIPTION
## Summary
- add a PF2e trait browser tool that dynamically reads trait dictionaries from the system configuration
- surface the new tool in the Handy Dandy controls, tool overview, and documentation
- add template and styling to list traits, show details, and support copying slugs

## Testing
- npm run build
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68eb03b2dc78832fbeb15a4f57774d9c