### PR TITLE
Improve prompt workbench UI and add actor import support

### DIFF
--- a/src/scripts/flows/prompt-workbench-ui.ts
+++ b/src/scripts/flows/prompt-workbench-ui.ts
@@ -71,69 +71,98 @@ export async function runPromptWorkbenchFlow(): Promise<void> {
 async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityType> | null> {
   const systemOptions = SYSTEM_IDS.map((id) => `<option value="${id}">${id.toUpperCase()}</option>`).join("");
   const content = `
+    <style>
+      .handy-dandy-workbench-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .handy-dandy-workbench-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      }
+
+      .handy-dandy-workbench-form fieldset {
+        margin: 0;
+      }
+
+      .handy-dandy-workbench-form .notes {
+        margin: 0.25rem 0 0;
+        font-size: 0.85em;
+        color: var(--color-text-light-6, #bbb);
+      }
+
+      .handy-dandy-workbench-form textarea {
+        min-height: 12rem;
+        resize: vertical;
+        width: 100%;
+      }
+
+      .handy-dandy-workbench-form .form-fields {
+        display: grid;
+        gap: 0.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        align-items: center;
+      }
+    </style>
     <form class="handy-dandy-workbench-form">
-      <div class="form-group">
-        <label>Entity Type</label>
-        <select name="entityType">
-          <option value="action">Action</option>
-          <option value="item">Item</option>
-          <option value="actor">Actor</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label>Game System</label>
-        <select name="systemId">
-          ${systemOptions}
-        </select>
-      </div>
-      <div class="form-group">
-        <label>Name / Title</label>
-        <input type="text" name="entryName" required />
-        <p class="notes">Use the action title, item name, or actor name you want in Foundry.</p>
-      </div>
-      <div class="form-group">
-        <label>Slug (optional)</label>
-        <input type="text" name="slug" />
+      <div class="handy-dandy-workbench-grid">
+        <div class="form-group">
+          <label>Entity Type</label>
+          <select name="entityType">
+            <option value="actor">Actor</option>
+            <option value="action">Action</option>
+            <option value="item">Item</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Game System</label>
+          <select name="systemId">
+            ${systemOptions}
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Name / Title</label>
+          <input type="text" name="entryName" required />
+          <p class="notes">Use the actor name, action title, or item name you want in Foundry.</p>
+        </div>
+        <div class="form-group">
+          <label>Slug (optional)</label>
+          <input type="text" name="slug" />
+        </div>
       </div>
       <fieldset class="form-group">
         <legend>Publication Details</legend>
-        <div class="form-group">
-          <label>Title</label>
-          <input type="text" name="publicationTitle" value="" />
-        </div>
-        <div class="form-group">
-          <label>Authors</label>
-          <input type="text" name="publicationAuthors" value="" />
-        </div>
-        <div class="form-group">
-          <label>License</label>
-          <input type="text" name="publicationLicense" value="OGL" />
-        </div>
-        <div class="form-group form-fields">
-          <label>
-            <input type="checkbox" name="publicationRemaster" /> Remaster
-          </label>
+        <div class="form-fields">
+          <label>Title <input type="text" name="publicationTitle" value="" /></label>
+          <label>Authors <input type="text" name="publicationAuthors" value="" /></label>
+          <label>License <input type="text" name="publicationLicense" value="OGL" /></label>
+          <label><input type="checkbox" name="publicationRemaster" /> Remaster</label>
         </div>
       </fieldset>
-      <div class="form-group">
-        <label>Image Path</label>
-        <input type="text" name="img" value="${DEFAULT_IMAGE_PATH}" />
-        <p class="notes">Provide a Foundry asset path or URL for the generated image.</p>
+      <div class="handy-dandy-workbench-grid">
+        <div class="form-group">
+          <label>Image Path</label>
+          <input type="text" name="img" value="${DEFAULT_IMAGE_PATH}" />
+          <p class="notes">Provide a Foundry asset path or URL for the generated image.</p>
+        </div>
+        <fieldset class="form-group">
+          <legend>Advanced Options</legend>
+          <div class="form-fields">
+            <label>Seed <input type="number" name="seed" /></label>
+            <label>Max Attempts <input type="number" name="maxAttempts" min="1" /></label>
+            <label>Compendium Pack ID <input type="text" name="packId" /></label>
+            <label>Folder ID <input type="text" name="folderId" /></label>
+          </div>
+        </fieldset>
       </div>
       <div class="form-group">
         <label>Reference Text or Prompt</label>
-        <textarea name="referenceText" rows="8" style="width: 100%;" required></textarea>
+        <textarea name="referenceText" required></textarea>
         <p class="notes">Paste rules text, stat blocks, or a creative prompt for the generator to follow.</p>
       </div>
-      <fieldset class="form-group">
-        <legend>Advanced Options</legend>
-        <div class="form-fields">
-          <label>Seed <input type="number" name="seed" /></label>
-          <label>Max Attempts <input type="number" name="maxAttempts" min="1" /></label>
-          <label>Compendium Pack ID <input type="text" name="packId" /></label>
-          <label>Folder ID <input type="text" name="folderId" /></label>
-        </div>
-      </fieldset>
     </form>
   `;
 
@@ -184,7 +213,7 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
         folderId: String(formData.get("folderId") ?? ""),
       };
     },
-    options: { jQuery: true },
+    options: { jQuery: true, width: 680 },
   });
 
   if (!response) {
@@ -295,8 +324,21 @@ async function showWorkbenchResult(result: PromptWorkbenchResult<EntityType>): P
 
   const content = `
     <form class="handy-dandy-workbench-result">
+      <style>
+        .handy-dandy-workbench-result {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+        }
+
+        .handy-dandy-workbench-result textarea {
+          min-height: 16rem;
+          resize: vertical;
+          width: 100%;
+        }
+      </style>
       <p class="notes">Review the generated JSON below. Use the buttons to copy, download, or import.</p>
-      <textarea name="generatedJson" rows="16" readonly style="width: 100%;">${escaped}</textarea>
+      <textarea name="generatedJson" rows="16" readonly>${escaped}</textarea>
     </form>
   `;
 
@@ -307,7 +349,7 @@ async function showWorkbenchResult(result: PromptWorkbenchResult<EntityType>): P
       buttons: buildResultButtons(result, json, importerAvailable),
       close: () => resolve(),
       default: "close",
-    }, { jQuery: true });
+    }, { jQuery: true, width: 700 });
 
     dialog.render(true);
   });
@@ -353,9 +395,10 @@ function buildResultButtons(
   };
 
   if (importerAvailable && result.importer) {
+    const importLabel = result.type === "actor" ? "Create Actor" : "Import to World";
     buttons.import = {
       icon: '<i class="fas fa-cloud-upload-alt"></i>',
-      label: "Import to World",
+      label: importLabel,
       callback: async () => {
         try {
           const document = await result.importer?.();
@@ -363,6 +406,9 @@ function buildResultButtons(
           ui.notifications?.info(
             `${CONSTANTS.MODULE_NAME} | Imported ${resolvedName}${document?.uuid ? ` (${document.uuid})` : ""}.`,
           );
+          if (result.type === "actor" && document instanceof Actor) {
+            document.sheet?.render(true);
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           ui.notifications?.error(`${CONSTANTS.MODULE_NAME} | Import failed: ${message}`);

--- a/src/scripts/flows/prompt-workbench.ts
+++ b/src/scripts/flows/prompt-workbench.ts
@@ -1,5 +1,5 @@
 import { fromFoundryAction, fromFoundryActor, fromFoundryItem } from "../mappers/export";
-import { importAction } from "../mappers/import";
+import { importAction, importActor } from "../mappers/import";
 import {
   PUBLICATION_DEFAULT,
   type CanonicalEntityMap,
@@ -82,7 +82,7 @@ type GeneratorMap = {
 
 type ImporterMap = {
   [K in EntityType]: (
-    json: CanonicalEntityMap[K],
+    json: GeneratedEntityMap[K],
     options?: ImporterOptions,
   ) => Promise<ClientDocument>;
 };
@@ -95,6 +95,7 @@ const GENERATION_METHOD_MAP: Record<EntityType, keyof NonNullable<Game["handyDan
 
 const DEFAULT_IMPORTERS: Partial<ImporterMap> = {
   action: async (json, options) => importAction(json, options),
+  actor: async (json, options) => importActor(json, options),
 };
 
 interface BoundGenerationOptions {
@@ -193,8 +194,7 @@ export async function generateWorkbenchEntry<T extends EntityType>(
   const resolvedName = data.name.trim() || inferInputName(type, input);
 
   const importerFn = importer
-    ? (options?: ImporterOptions) =>
-        importer(data as unknown as CanonicalEntityMap[T], { packId, folderId, ...options })
+    ? (options?: ImporterOptions) => importer(data, { packId, folderId, ...options })
     : undefined;
 
   return {


### PR DESCRIPTION
## Summary
- restyle the prompt workbench form to widen the dialog and make the actor option the default selection
- add a dedicated "Create Actor" action in the result dialog that imports generated actors directly into the world
- implement actor import helpers to create or update actor documents alongside the existing action importer

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68eb1cb87604832fb7c7072f96169a63