### PR TITLE
Add level and actor content options to prompt workbench form

### DIFF
--- a/src/scripts/flows/prompt-workbench-ui.ts
+++ b/src/scripts/flows/prompt-workbench-ui.ts
@@ -356,6 +356,11 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
               <label>Slug (optional)</label>
               <input type="text" name="slug" />
             </div>
+            <div class="form-group">
+              <label>Level</label>
+              <input type="number" name="level" min="0" />
+              <p class="notes">Provide a level for actors; leave blank for other entries.</p>
+            </div>
           </div>
           <fieldset class="form-group">
             <legend>Publication Details</legend>
@@ -387,6 +392,14 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
             <textarea name="referenceText" required></textarea>
             <p class="notes">Paste rules text, stat blocks, or a creative prompt for the generator to follow.</p>
           </div>
+          <fieldset class="form-group">
+            <legend>Actor Content</legend>
+            <div class="form-fields">
+              <label><input type="checkbox" name="includeSpellcasting" /> Spellcasting?</label>
+              <label><input type="checkbox" name="includeInventory" /> Inventory?</label>
+            </div>
+            <p class="notes">Use these options to guide actor prompts.</p>
+          </fieldset>
         </form>
       </section>
       <section class="handy-dandy-workbench-panel" data-panel="history">
@@ -407,6 +420,7 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
         systemId: string;
         entryName: string;
         slug: string;
+        level: string;
         publicationTitle: string;
         publicationAuthors: string;
         publicationLicense: string;
@@ -417,6 +431,8 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
         maxAttempts: string;
         packId: string;
         folderId: string;
+        includeSpellcasting: string | null;
+        includeInventory: string | null;
       }
     | null
   >((resolve) => {
@@ -467,6 +483,7 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
                 systemId: String(formData.get("systemId") ?? ""),
                 entryName: String(formData.get("entryName") ?? ""),
                 slug: String(formData.get("slug") ?? ""),
+                level: String(formData.get("level") ?? ""),
                 publicationTitle: String(formData.get("publicationTitle") ?? ""),
                 publicationAuthors: String(formData.get("publicationAuthors") ?? ""),
                 publicationLicense: String(formData.get("publicationLicense") ?? ""),
@@ -477,6 +494,8 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
                 maxAttempts: String(formData.get("maxAttempts") ?? ""),
                 packId: String(formData.get("packId") ?? ""),
                 folderId: String(formData.get("folderId") ?? ""),
+                includeSpellcasting: formData.get("includeSpellcasting") as string | null,
+                includeInventory: formData.get("includeInventory") as string | null,
               });
             },
           },
@@ -547,12 +566,15 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
     entryName,
     referenceText,
     slug: response.slug.trim() || undefined,
+    level: parseOptionalNumber(response.level),
     seed: parseOptionalNumber(response.seed),
     maxAttempts: parseOptionalNumber(response.maxAttempts),
     packId: response.packId.trim() || undefined,
     folderId: response.folderId.trim() || undefined,
     publication,
     img,
+    includeSpellcasting: response.includeSpellcasting ? true : undefined,
+    includeInventory: response.includeInventory ? true : undefined,
   } satisfies PromptWorkbenchRequest<EntityType>;
 }
 

--- a/src/scripts/flows/prompt-workbench.ts
+++ b/src/scripts/flows/prompt-workbench.ts
@@ -58,11 +58,14 @@ export interface PromptWorkbenchRequest<T extends EntityType> extends ImporterOp
   readonly entryName: string;
   readonly referenceText: string;
   readonly slug?: string;
+  readonly level?: number;
   readonly seed?: number;
   readonly maxAttempts?: number;
   readonly dependencies?: GenerationDependencyOverrides;
   readonly img?: string;
   readonly publication?: PublicationData;
+  readonly includeSpellcasting?: boolean;
+  readonly includeInventory?: boolean;
 }
 
 export interface PromptWorkbenchResult<T extends EntityType> {
@@ -170,6 +173,7 @@ export async function generateWorkbenchEntry<T extends EntityType>(
     entryName,
     referenceText,
     slug,
+    level,
     seed,
     maxAttempts,
     packId,
@@ -177,6 +181,8 @@ export async function generateWorkbenchEntry<T extends EntityType>(
     dependencies = {},
     img,
     publication,
+    includeSpellcasting,
+    includeInventory,
   } = request;
 
   const generator = resolveGenerator(type, dependencies.generators);
@@ -188,6 +194,9 @@ export async function generateWorkbenchEntry<T extends EntityType>(
     slug,
     img,
     publication,
+    level,
+    includeSpellcasting,
+    includeInventory,
   });
 
   const data = await generator(input, { seed, maxAttempts });
@@ -217,9 +226,20 @@ function buildPromptInput<T extends EntityType>(
     slug?: string;
     img?: string;
     publication?: PublicationData;
+    level?: number;
+    includeSpellcasting?: boolean;
+    includeInventory?: boolean;
   },
 ): PromptInputMap[T] {
-  const { systemId, entryName, referenceText, slug } = context;
+  const {
+    systemId,
+    entryName,
+    referenceText,
+    slug,
+    level,
+    includeSpellcasting,
+    includeInventory,
+  } = context;
   const img = context.img?.trim() || DEFAULT_IMAGE_PATH;
   const publication = normalizePublicationInput(context.publication);
   switch (type) {
@@ -249,6 +269,9 @@ function buildPromptInput<T extends EntityType>(
         slug,
         img,
         publication,
+        level,
+        includeSpellcasting,
+        includeInventory,
       } satisfies ActorPromptInput as PromptInputMap[T];
     default:
       throw new Error(`Unsupported entity type: ${type satisfies never}`);

--- a/src/scripts/prompts/actors.ts
+++ b/src/scripts/prompts/actors.ts
@@ -21,6 +21,9 @@ export interface ActorPromptInput {
   readonly correction?: CorrectionContext;
   readonly img?: string;
   readonly publication?: PublicationData;
+  readonly level?: number;
+  readonly includeSpellcasting?: boolean;
+  readonly includeInventory?: boolean;
 }
 
 function buildActorSchemaSection(): string {
@@ -81,8 +84,17 @@ function buildActorRequest(input: ActorPromptInput): string {
     input.referenceText.trim()
   ];
 
+  const details: string[] = [];
   if (input.slug) {
-    parts.splice(1, 0, `Slug suggestion: ${input.slug}`);
+    details.push(`Slug suggestion: ${input.slug}`);
+  }
+
+  if (typeof input.level === "number" && Number.isFinite(input.level)) {
+    details.push(`Target level: ${input.level}`);
+  }
+
+  if (details.length) {
+    parts.splice(1, 0, ...details);
   }
 
   const publicationSection = renderPublicationSection(input.publication);
@@ -93,6 +105,14 @@ function buildActorRequest(input: ActorPromptInput): string {
   const imageInstruction = renderImageInstruction(input.img);
   if (imageInstruction) {
     parts.push(imageInstruction);
+  }
+
+  if (input.includeSpellcasting) {
+    parts.push("Include spellcasting data that aligns with the reference text.");
+  }
+
+  if (input.includeInventory) {
+    parts.push("List an inventory section covering notable gear, treasure, and equipment carried.");
   }
 
   return parts.join("\n\n");


### PR DESCRIPTION
## Summary
- add a level input plus spellcasting and inventory checkboxes to the prompt workbench form
- carry the new form values through prompt request handling and actor prompt inputs
- update actor prompt generation to mention the requested level and optional sections

## Testing
- npm test *(fails in this environment: Windows-specific xcopy command)*

------
https://chatgpt.com/codex/tasks/task_e_68ec125d62c4832fa00df88177214614