### PR TITLE
Add placeholder NPC prompt remix dialog

### DIFF
--- a/src/scripts/module.ts
+++ b/src/scripts/module.ts
@@ -11,6 +11,7 @@ import { DeveloperConsole } from "./dev/developer-console";
 import { setDeveloperConsole } from "./dev/state";
 import { createDevNamespace, canUseDeveloperTools, type DevNamespace } from "./dev/tools";
 import { ToolOverview } from "./ui/tool-overview";
+import { registerNpcRemixButton } from "./ui/npc-remix-button";
 import {
   DEFAULT_GENERATION_SEED,
   generateAction,
@@ -51,6 +52,8 @@ type BoundGenerateActor = (
   input: ActorPromptInput,
   options?: BoundGenerationOptions,
 ) => Promise<ActorGenerationResult>;
+
+registerNpcRemixButton();
 
 function bindGenerator<TInput, TResult>(
   fn: GeneratorFunction<TInput, TResult>,

--- a/src/scripts/ui/npc-remix-button.ts
+++ b/src/scripts/ui/npc-remix-button.ts
@@ -1,0 +1,62 @@
+import { CONSTANTS } from "../constants";
+
+const BUTTON_CLASS = "handy-dandy-npc-remix-button" as const;
+const BUTTON_ICON_CLASS = "fas fa-random" as const;
+const BUTTON_LABEL = "Remix Prompt" as const;
+const BUTTON_TITLE = "Open the Handy Dandy prompt remix placeholder" as const;
+
+export function registerNpcRemixButton(): void {
+  Hooks.on("renderActorSheetPF2e", (app: ActorSheet, html: JQuery<HTMLElement>) => {
+    const actor = app.actor;
+    if (!(actor instanceof Actor)) return;
+
+    const actorType = actor.type as unknown as string;
+    if (actorType !== "npc") return;
+
+    const user = game.user;
+    if (!user) return;
+    if (!user.isGM && !app.document?.isOwner) return;
+
+    const windowHeader = html.find(".window-header");
+    if (windowHeader.length === 0) return;
+
+    if (windowHeader.find(`.${BUTTON_CLASS}`).length > 0) return;
+
+    const closeButton = windowHeader.find(".close");
+    const button = $(
+      `<a class="${BUTTON_CLASS}" title="${BUTTON_TITLE}">
+        <i class="${BUTTON_ICON_CLASS}"></i>
+        <span>${BUTTON_LABEL}</span>
+      </a>`,
+    );
+
+    if (closeButton.length > 0) {
+      closeButton.before(button);
+    } else {
+      windowHeader.append(button);
+    }
+
+    button.on("click", event => {
+      event.preventDefault();
+      openPlaceholderDialog(actor.name ?? CONSTANTS.MODULE_NAME);
+    });
+  });
+}
+
+function openPlaceholderDialog(actorName: string): void {
+  const dialog = new Dialog({
+    title: `${actorName} Prompt Remix`,
+    content:
+      "<p>This placeholder dialogue will host the upcoming prompt remix experience.</p>" +
+      "<p>No actions are available yet, but stay tuned!</p>",
+    buttons: {
+      close: {
+        icon: "<i class=\"fas fa-times\"></i>",
+        label: "Close",
+      },
+    },
+    default: "close",
+  });
+
+  dialog.render(true);
+}


### PR DESCRIPTION
## Summary
- add a Remix Prompt button to PF2e NPC actor sheets for owners and GMs
- open a placeholder dialog describing the upcoming NPC prompt remix workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec18b9643c832f8f4ea30317c6e189