### PR TITLE
Fix prompt workbench CSS escape sequence

### DIFF
--- a/src/scripts/flows/prompt-workbench-ui.ts
+++ b/src/scripts/flows/prompt-workbench-ui.ts
@@ -281,7 +281,7 @@ async function promptWorkbenchRequest(): Promise<PromptWorkbenchRequest<EntityTy
       }
 
       .handy-dandy-workbench-advanced > summary::after {
-        content: "\25bc";
+        content: "\\25BC";
         font-size: 0.85em;
         transition: transform 0.2s ease;
       }


### PR DESCRIPTION
## Summary
- escape the CSS content string in the prompt workbench markup to avoid octal escapes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ec1bae6cc8832fb72af45a5eec3188