### PR TITLE
Produce canonical PF2e item JSON and enable imports

### DIFF
--- a/src/scripts/flows/prompt-workbench-ui.ts
+++ b/src/scripts/flows/prompt-workbench-ui.ts
@@ -16,7 +16,7 @@ import {
   type PublicationData,
   type SystemId,
 } from "../schemas";
-import { importAction, importActor } from "../mappers/import";
+import { importAction, importActor, importItem } from "../mappers/import";
 
 interface WorkbenchHistoryEntry {
   readonly id: string;
@@ -882,6 +882,8 @@ function createHistoryImporter(
   switch (type) {
     case "action":
       return () => importAction(data as GeneratedEntityMap["action"]);
+    case "item":
+      return () => importItem(data as GeneratedEntityMap["item"]);
     case "actor":
       return () => importActor(data as GeneratedEntityMap["actor"]);
     default:

--- a/src/scripts/flows/prompt-workbench.ts
+++ b/src/scripts/flows/prompt-workbench.ts
@@ -1,5 +1,5 @@
 import { fromFoundryAction, fromFoundryActor, fromFoundryItem } from "../mappers/export";
-import { importAction, importActor } from "../mappers/import";
+import { importAction, importActor, importItem } from "../mappers/import";
 import {
   PUBLICATION_DEFAULT,
   type CanonicalEntityMap,
@@ -100,6 +100,7 @@ const GENERATION_METHOD_MAP: Record<EntityType, keyof NonNullable<Game["handyDan
 
 const DEFAULT_IMPORTERS: Partial<ImporterMap> = {
   action: async (json, options) => importAction(json, options),
+  item: async (json, options) => importItem(json, options),
   actor: async (json, options) => importActor(json, options),
 };
 


### PR DESCRIPTION
## Summary
- update the PF2e item mapper to emit canonical Foundry structures with default metadata and stats so generated JSON matches example exports
- add helpers for item identification, usage, and version tracking plus an importItem function to re-create or update world entries
- expose the new importer in the workbench so generated items offer a working "Import to World" action

## Testing
- npm run test:validation

------
https://chatgpt.com/codex/tasks/task_e_68ec42a91548832f8696106a17f3d123